### PR TITLE
Add continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: java
+script: mvn test -f ./source/tests/functional/NYCAutomationTest/pom.xml

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -623,3 +623,14 @@ and once we've figured out the solution we'll list it here too.
     `service httpd restart` 
 
     `./bin/shutdown.sh` (from within the apache-tomcat directory)
+
+
+Continuous integration:
+----------------------
+
+To set up continuous integration for a fork of this repository, follow
+the instructions at
+[Travis](https://docs.travis-ci.com/user/getting-started/).  We've
+already added the .travis.yml file to this repo, so all you need to do
+is turn on CI for your fork, as described on that page.
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Checkbook NYC
 =============
 
+Current build status of `develop` branch: ![Build
+status](https://travis-ci.org/OpenTechStrategies/Checkbook.svg?branch=develop)
+
 Checkbook NYC is an open source financial transparency web application.
 
 Checkbook provides transparent access to a city's or other jurisdiction's

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Checkbook NYC
 =============
 
 Current build status of `develop` branch: ![Build
-status](https://travis-ci.org/OpenTechStrategies/Checkbook.svg?branch=develop)
+status](https://travis-ci.org/NYCComptroller/Checkbook.svg?branch=develop)
 
 Checkbook NYC is an open source financial transparency web application.
 


### PR DESCRIPTION
Add Travis CI to this repository so that each commit will trigger a run of the tests.  This will help avoid regressions.

Note that the tests will always fail (currently) because they depend on a database connection set in `conf.properties`.  I'll open a separate issue about changing the defaults in that file. 