### PR TITLE
NYCCHKBK-7557 - Peer Review Request

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_project/customclasses/RequestUtil.php
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/customclasses/RequestUtil.php
@@ -638,12 +638,6 @@ class RequestUtil{
                 if(_getRequestParamValue("vendor") > 0){
                     $path =  $path . "/vendor/" . _getRequestParamValue("vendor")  ;
                 }
-                if(_getRequestParamValue("vendornm_exact") != NULL){
-                    $vendor_id = PrimeVendorService::getVendorIdByName(_getRequestParamValue('vendornm_exact'));
-                    $path = isset($vendor_id)
-                        ? "contracts_landing".ContractsUrlService::primeVendorUrl($vendor_id)
-                        : $path;
-                }
                 break;
             case "spending":
                 $path ="spending_landing/yeartype/B/year/".$fiscalYearId._checkbook_append_url_params(null, array(),true);
@@ -950,11 +944,11 @@ class RequestUtil{
     			break;
     	}
     }
-
-
+        
+    
     static function getDashboardTopNavURL($dashboard_filter){
-
-
+    	
+    	
     	if(self::isContractsSpendingLandingPage()){
     		$url = $_GET['q'];
 
@@ -965,15 +959,15 @@ class RequestUtil{
                 $override_params = array("category"=>null);
                 $url =  SpendingUtil::getLandingPageWidgetUrl($override_params);
     		}
-
+    		
     	}else{
     		$url = self::getCurrentDomainURLFromParams();
     	}
 
         switch($dashboard_filter){
     		case "mwbe":
-    	    	if(_getRequestParamValue("dashboard") !=  null){
-    				$url = preg_replace('/\/dashboard\/[^\/]*/','',$url);
+    	    	if(_getRequestParamValue("dashboard") !=  null){    				
+    				$url = preg_replace('/\/dashboard\/[^\/]*/','',$url);    				   				    				    				
     			}
     			$url .=  "/dashboard/" . self::getNextMWBEDashboardStateParam();
     			if(!preg_match('/mwbe/',$url)){
@@ -983,12 +977,6 @@ class RequestUtil{
     					$url .=  "/mwbe/2~3~4~5~9";
     				}
     			}
-                if(_getRequestParamValue("vendornm_exact") != NULL){
-                    $vendor_id = PrimeVendorService::getVendorIdByName(_getRequestParamValue('vendornm_exact'));
-                    $url = isset($vendor_id)
-                        ? "contracts_landing".ContractsUrlService::primeVendorUrl($vendor_id)
-                        : $url;
-                }
     			break;
     		case "subvendor":
     			
@@ -999,12 +987,7 @@ class RequestUtil{
 				if(_getRequestParamValue("dashboard") == 'ms' && _getRequestParamValue("mwbe") == '2~3~4~5~9' && _getRequestParamValue("tm_wbe") != 'Y'){
     				$url = preg_replace('/\/mwbe\/[^\/]*/','',$url);
     			}
-                if(_getRequestParamValue("vendornm_exact") != NULL){
-                    $vendor_id = SubVendorService::getVendorIdByName(_getRequestParamValue('vendornm_exact'));
-                    $url = isset($vendor_id)
-                        ? "contracts_landing".ContractsUrlService::subVendorUrl($vendor_id)
-                        : $url;
-                }
+    			
     			$url .=  "/dashboard/" . self::getNextSubvendorDashboardStateParam();    			
     			break;
     	}
@@ -1252,29 +1235,5 @@ class RequestUtil{
 
     static function checkDomain($domain) {
         return preg_match('/^'.$domain.'/',current_path());
-    }
-
-    /**
-     * Given a vendor name, returns a list of vendor ids, either prime, sub or both
-     * @param $vendor_name
-     * @param null $vendor_type
-     * @return string
-     */
-    static function getVendorFilterForTopNavigation($vendor_name, $vendor_type = null) {
-
-        if($vendor_name == null) return null;
-        $vendors = array();
-        switch($vendor_type) {
-            case VendorType::$PRIME_VENDOR:
-                $vendors[] = PrimeVendorService::getVendorIdByName($vendor_name);
-                break;
-            case VendorType::$SUB_VENDOR:
-                $vendors[] = SubVendorService::getVendorIdByName($vendor_name);
-                break;
-            default:
-                $vendors = VendorService::getVendorIdByName($vendor_name);
-                break;
-        }
-        return implode('~',$vendors);
     }
 }

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/home/top_slider/472.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/home/top_slider/472.json
@@ -21,6 +21,7 @@
         if(!preg_match('/payroll/',$_SERVER['REQUEST_URI'])){
             unset($node->widgetConfig->model->series[1]->seriesURLParamMap->yeartype);
         }
+        
     ",
     
     "model": {
@@ -35,12 +36,6 @@
                 "allowedParams":["vendor_id","fiscal_year_id","agency_id","calyear"],
                 "seriesDefaultParameters":{"document_code.document_code.document_code":"CT1~CTA1~RCT1~MA1","contract_status.contract_status":"R","type_of_year":"B"},
                 "adjustSerieParameters":"
-                    if(_getRequestParamValue('vendornm_exact') != NULL) {
-                        $vendor_id = RequestUtil::getVendorFilterForTopNavigation(_getRequestParamValue('vendornm_exact'),'P');
-                        if($vendor_id != NULL) {
-                            $serieParameters['vendor_id'] = $vendor_id;
-                        }
-                    }
                     $serieParameters['fiscal_year_id'] = RequestUtil::getFiscalYearIdForTopNavigation();
                     return $serieParameters;
                 "
@@ -59,12 +54,6 @@
                 "allowedParams":["vendor_id","year.year","agency_id","calyear"],
                 "seriesDefaultParameters":{"type_of_year":"B"},
                 "adjustSerieParameters":"
-                    if(_getRequestParamValue('vendornm_exact') != NULL) {
-                        $vendor_id = RequestUtil::getVendorFilterForTopNavigation(_getRequestParamValue('vendornm_exact'),'P');
-                        if($vendor_id != NULL) {
-                            $serieParameters['vendor_id'] = $vendor_id;
-                        }
-                    }
                     $serieParameters['year.year'] = RequestUtil::getFiscalYearIdForTopNavigation();
                     return $serieParameters;
                 "
@@ -106,16 +95,7 @@
                 "seriesURLParamMap":{"vendor":"vendor_id","calyear":"fiscal_year_id","year":"fiscal_year_id","agency":"agency_id","mwbe":"minority_type_id"},
                 "allowedParams":["vendor_id","fiscal_year_id","agency_id","minority_type_id","calyear"],
                 "seriesDefaultParameters":{"document_code.document_code.document_code":"CT1~CTA1~RCT1~MA1","contract_status.contract_status":"R",
-                "type_of_year":"B","minority_type_id":"2~3~4~5~9"},
-                "adjustSerieParameters":"
-                    if(_getRequestParamValue('vendornm_exact') != NULL) {
-                        $vendor_id = RequestUtil::getVendorFilterForTopNavigation(_getRequestParamValue('vendornm_exact'));
-                        if($vendor_id != NULL) {
-                            $serieParameters['vendor_id'] = $vendor_id;
-                        }
-                    }
-                    return $serieParameters;
-                "
+                "type_of_year":"B","minority_type_id":"2~3~4~5~9"}
             },
             {
                 "dataset":"checkbook:spending_subven_data",
@@ -133,13 +113,7 @@
                 "columns":["current_amount_sum","total_contracts"],
                 "seriesURLParamMap":{"subvendor":"vendor_id","vendor":"prime_vendor_id","calyear":"fiscal_year_id","year":"fiscal_year_id","agency":"agency_id","mwbe":"minority_type_id"},
                 "allowedParams":["prime_vendor_id","vendor_id","fiscal_year_id","agency_id","minority_type_id","calyear"],
-                "seriesDefaultParameters":{"document_code.document_code.document_code":"CT1~CTA1~RCT1~MA1","contract_status.contract_status":"R","type_of_year":"B"},
-                "adjustSerieParameters":"
-                    if(_getRequestParamValue('vendornm_exact') != NULL) {
-                        $serieParameters['vendor_id'] = RequestUtil::getVendorFilterForTopNavigation(_getRequestParamValue('vendornm_exact'));
-                    }
-                    return $serieParameters;
-                "
+                "seriesDefaultParameters":{"document_code.document_code.document_code":"CT1~CTA1~RCT1~MA1","contract_status.contract_status":"R","type_of_year":"B"}
             },
             {
                 "dataset":"checkbook:spending_subven_data",
@@ -157,71 +131,35 @@
                 "columns":["current_amount_sum","total_contracts"],
                 "seriesURLParamMap":{"subvendor":"vendor_id","vendor":"prime_vendor_id","calyear":"fiscal_year_id","year":"fiscal_year_id","agency":"agency_id","mwbe":"minority_type_id"},
                 "allowedParams":["vendor_id","prime_vendor_id","fiscal_year_id","agency_id","minority_type_id","calyear"],
-                "seriesDefaultParameters":{"document_code.document_code.document_code":"CT1~CTA1~RCT1~MA1","contract_status.contract_status":"R","type_of_year":"B","minority_type_id":"2~3~4~5~9"},
-                "adjustSerieParameters":"
-                    if(_getRequestParamValue('vendornm_exact') != NULL) {
-                        $serieParameters['vendor_id'] = RequestUtil::getVendorFilterForTopNavigation(_getRequestParamValue('vendornm_exact'));
-                    }
-                    return $serieParameters;
-                "
+                "seriesDefaultParameters":{"document_code.document_code.document_code":"CT1~CTA1~RCT1~MA1","contract_status.contract_status":"R","type_of_year":"B","minority_type_id":"2~3~4~5~9"}
             },
             {
                 "dataset":"checkbook:mwbe_contracts_coa_aggregates",
                 "columns":["current_amount_sum"],
                 "seriesURLParamMap":{"vendor":"vendor_id","calyear":"fiscal_year_id","year":"fiscal_year_id","agency":"agency_id","mwbe":"minority_type_id"},
                 "allowedParams":["vendor_id","fiscal_year_id","agency_id","minority_type_id","calyear"],
-                "seriesDefaultParameters":{"document_code.document_code.document_code":"CT1~CTA1~RCT1~MA1","contract_status.contract_status":"A","type_of_year":"B","minority_type_id":"2~3~4~5~9"},
-                "adjustSerieParameters":"
-                    if(_getRequestParamValue('vendornm_exact') != NULL) {
-                        $vendor_id = RequestUtil::getVendorFilterForTopNavigation(_getRequestParamValue('vendornm_exact'));
-                        if($vendor_id != NULL) {
-                            $serieParameters['vendor_id'] = $vendor_id;
-                        }
-                    }
-                    return $serieParameters;
-                "
+                "seriesDefaultParameters":{"document_code.document_code.document_code":"CT1~CTA1~RCT1~MA1","contract_status.contract_status":"A","type_of_year":"B","minority_type_id":"2~3~4~5~9"}
             },
             {
                 "dataset":"checkbook:subven_contracts_coa_aggregates",
                 "columns":["current_amount_sum"],
                 "seriesURLParamMap":{"subvendor":"vendor_id","vendor":"prime_vendor_id","calyear":"fiscal_year_id","year":"fiscal_year_id","agency":"agency_id","mwbe":"minority_type_id"},
                 "allowedParams":["prime_vendor_id","vendor_id","fiscal_year_id","agency_id","minority_type_id","calyear"],
-                "seriesDefaultParameters":{"document_code.document_code.document_code":"CT1~CTA1~RCT1~MA1","contract_status.contract_status":"A","type_of_year":"B"},
-                "adjustSerieParameters":"
-                    if(_getRequestParamValue('vendornm_exact') != NULL) {
-                        $serieParameters['vendor_id'] = RequestUtil::getVendorFilterForTopNavigation(_getRequestParamValue('vendornm_exact'));
-                    }
-                    return $serieParameters;
-                "
+                "seriesDefaultParameters":{"document_code.document_code.document_code":"CT1~CTA1~RCT1~MA1","contract_status.contract_status":"A","type_of_year":"B"}
             },
             {
                 "dataset":"checkbook:subven_contracts_coa_aggregates",
                 "columns":["current_amount_sum"],
                 "seriesURLParamMap":{"subvendor":"vendor_id","vendor":"prime_vendor_id","calyear":"fiscal_year_id","year":"fiscal_year_id","agency":"agency_id","mwbe":"minority_type_id"},
                 "allowedParams":["vendor_id","prime_vendor_id","fiscal_year_id","agency_id","minority_type_id","calyear"],
-                "seriesDefaultParameters":{"document_code.document_code.document_code":"CT1~CTA1~RCT1~MA1","contract_status.contract_status":"A","type_of_year":"B","minority_type_id":"2~3~4~5~9"},
-                "adjustSerieParameters":"
-                    if(_getRequestParamValue('vendornm_exact') != NULL) {
-                        $serieParameters['vendor_id'] = RequestUtil::getVendorFilterForTopNavigation(_getRequestParamValue('vendornm_exact'));
-                    }
-                    return $serieParameters;
-                "
+                "seriesDefaultParameters":{"document_code.document_code.document_code":"CT1~CTA1~RCT1~MA1","contract_status.contract_status":"A","type_of_year":"B","minority_type_id":"2~3~4~5~9"}
             },
             {
                 "dataset":"checkbook:contracts_coa_aggregates",
                 "columns":["current_amount_sum","total_contracts"],
                 "seriesURLParamMap":{"vendor":"vendor_id","calyear":"fiscal_year_id","year":"fiscal_year_id","agency":"agency_id"},
                 "allowedParams":["vendor_id","fiscal_year_id","agency_id","calyear"],
-                "seriesDefaultParameters":{"document_code.document_code.document_code":"CT1~CTA1~RCT1~MA1","contract_status.contract_status":"A","type_of_year":"B"},
-                "adjustSerieParameters":"
-                    if(_getRequestParamValue('vendornm_exact') != NULL) {
-                        $vendor_id = RequestUtil::getVendorFilterForTopNavigation(_getRequestParamValue('vendornm_exact'),'P');
-                        if($vendor_id != NULL) {
-                            $serieParameters['vendor_id'] = $vendor_id;
-                        }
-                    }
-                    return $serieParameters;
-                "
+                "seriesDefaultParameters":{"document_code.document_code.document_code":"CT1~CTA1~RCT1~MA1","contract_status.contract_status":"A","type_of_year":"B"}
             }
         ]
     },


### PR DESCRIPTION
[NYCCHKBK-7557](https://tracker.reisys.com/browse/NYCCHKBK-7557) - Reverting only necessary changes for the vendor name exact filter in the contracts advanced search result, top navigation.

Saroja,

I only reverted changes I made to the top navigation to filter by the vendor name.  I have verified the issue raised here: [(NYCCHKBK-7635)](https://tracker.reisys.com/browse/NYCCHKBK-7635) is now fixed

Please verify that your changes still work.

Files Reverted:
source/webapp/sites/all/modules/custom/checkbook_project/customclasses/RequestUtil.php
source/webapp/sites/all/modules/custom/checkbook_project/widget_config/home/top_slider/472.json

You already reverted these, so I did not need to:
source/webapp/sites/all/modules/custom/checkbook_project/php_widgets/contracts_navigation.tpl.php 

Files Not Reverted.  These should be ok to leave, but please review for me:
source/webapp/sites/all/modules/custom/checkbook_project/widget_config/contracts/transaction_page_widgets/expense/939.json
source/webapp/sites/all/modules/custom/checkbook_widget_redesign/checkbook_business_layer/checkbook_services/common/PrimeVendorService.php
source/webapp/sites/all/modules/custom/checkbook_widget_redesign/checkbook_business_layer/checkbook_services/common/SubVendorService.php
source/webapp/sites/all/modules/custom/checkbook_widget_redesign/checkbook_business_layer/checkbook_services/common/VendorService.php
source/webapp/sites/all/modules/custom/checkbook_widget_redesign/checkbook_business_layer/checkbook_services/contracts/ContractsUrlService.php
source/webapp/sites/all/modules/custom/checkbook_widget_redesign/checkbook_infrastructure_layer/constants/CommonConstants.php 