### PR TITLE
Fix: Contracts Advanced Search- Status Order Mismatch

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_datafeeds/checkbook_datafeeds.module
+++ b/source/webapp/sites/all/modules/custom/checkbook_datafeeds/checkbook_datafeeds.module
@@ -1741,8 +1741,8 @@ function checkbook_datafeeds_contracts_filter_data($form, $form_state, $data_sou
                 '#title' => t('Status:'),
                 '#options' => array(
                     'active' => 'Active',
-                    'registered' => 'Registered',
                     'pending' => 'Pending',
+                    'registered' => 'Registered'
                 ),
                 '#attributes' => array('class' => array('watch')),
                 '#prefix' => '<div class="column column-left"><div class="datafield contractstatus">',


### PR DESCRIPTION
- Advanced Search: 
<img width="473" alt="screen shot 2017-08-29 at 3 57 40 pm" src="https://user-images.githubusercontent.com/6089683/29841329-019cb27a-8cd3-11e7-9500-918fe61e667a.png">

- Data Feeds:
<img width="649" alt="screen shot 2017-08-29 at 3 57 02 pm" src="https://user-images.githubusercontent.com/6089683/29841327-ffdef9fc-8cd2-11e7-87e8-2e562cc90961.png">
