### PR TITLE
NYCCHKBK -9361  Nycha spending hyperlinks for vendor and contract id charts

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/nycha_spending/charts/nycha_spending_across_years.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/nycha_spending/charts/nycha_spending_across_years.json
@@ -46,10 +46,11 @@ $data = array();
 $categories = array();
 $year_list = array('2010','2011','2012','2013','2014','2015','2016','2017','2018','2019');
 $cat = RequestUtilities::getRequestParamValue('category');
-
+$cat_name = 'Total';
 if ($cat != null){
 foreach ($node->data as $row){
-$link = NychaSpendingUrlService:: getFooterUrl();
+  $cat_name = $row['category_name_category_name'];
+//$link = NychaSpendingUrlService:: getFooterUrl();
   if ($cat == '2'){$row['invoice_amount_sum'] = $row['check_amount_sum'];}
 $categories[]=$row['issue_date_year_issue_date_year'];
 $data[] = (object)array('year'=>$row['issue_date_year_id'], 'y'=>$row['invoice_amount_sum'], 'url'=>$link, 'name'=>$row['issue_date_year_issue_date_year']);
@@ -63,7 +64,7 @@ foreach ($year_list as $list) {
     if ($row['issue_date_year_issue_date_year'] == $list) {
       $flag = 1;
       if ($row['category_name_category_name'] == 'Payroll') {$row['invoice_amount_sum'] = $row['check_amount_sum'];}
-    $link = NychaSpendingUrlService:: getFooterUrl();
+    //$link = NychaSpendingUrlService:: getFooterUrl();
     $year_value= $row['issue_date_year_issue_date_year'];
     $year_id = $row['issue_date_year_id'];
     $amount += $row['invoice_amount_sum'];
@@ -88,7 +89,7 @@ $amount = '';
 $node->widgetConfig->chartConfig->series[0]->data = $data;
 $node->widgetConfig->chartConfig->xAxis->categories = $categories;
 $node->widgetConfig->chartConfig->series[0]->name = 'Spending Amount';
-$node->widgetConfig->chartTitle = 'Total Spending Across Years';
+$node->widgetConfig->chartTitle = $cat_name.' Spending Across Years';
 return $node->data;
 ",
 "chartConfig": {
@@ -120,7 +121,6 @@ return $node->data;
 "plotOptions": {
 "column": {"pointWidth": 30},
 "series": {
-"cursor": "pointer",
 "point": {
 "events": {
 "function": "clickEvent"

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/nycha_spending/charts/nycha_spending_visual_1.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/nycha_spending/charts/nycha_spending_visual_1.json
@@ -59,13 +59,10 @@ FROM aggregation_spending_contracts_fy'.
 $where_filter.
 ' GROUP BY contract_id, contract_purpose, vendor_name, vendor_id ORDER BY check_amount_sum DESC LIMIT 10';
 $node->data  = _checkbook_project_execute_sql($sql,'main',$datasource);
-
 ",
 "widgetUpdateJSONConfig":"
-
 $series_new = [];
-
-
+$year_id = RequestUtilities::getRequestParamValue('year');
 $index = 0;
 foreach($node->data as $row){
 $tooltip_label =
@@ -73,12 +70,14 @@ $tooltip_label =
 'Amount: ' . custom_number_formatter_format($row['check_amount_sum'] ,2, '$').  '<br/>' .
 'Vendor: ' . $row['vendor_name'] .  '<br/>' ;
 
-list($link,) = explode('?',$_GET['q']);
-$link .= NychaContractsUrlService::contractDetailsUrl($row['contract_id'], true);
+ // $val = $_SERVER['SERVER_NAME'].'abcd'
+$link = 'nycha_contract_details' . '/year/'.$year_id.'/contract/' . $row['contract_id'] .'/newwindow';
+
+
 $series_new[$index]->url = 	$link;
 $series_new[$index]->y = (float)$row['check_amount_sum'];
 $series_new[$index]->tooltip_label = $tooltip_label;
-$node->widgetConfig->gridConfig->data[] = array($row['contract_id'],$row['vendor_name'],custom_number_formatter_format($row['check_amount_sum'] ,2, '$'),$link );
+$node->widgetConfig->gridConfig->data[] = array($row['contract_id'],$row['vendor_name'],custom_number_formatter_format($row['check_amount_sum'] ,2, '$'));
 $index += 1;
 }
 
@@ -133,5 +132,23 @@ yAxisFormatter^^'formatter' : function(){return yAxisLabelFormatter(this);}##
 tooltipformatter^^'formatter' :
 function() {return this.point.tooltip_label ;
 }##
-clickEvent^^"click": function(){location.href = Drupal.settings.basePath+this.url; }
+##clickEvent^^"click": function(){
+var newWindow = window.open(Drupal.settings.basePath+this.options.url, '_blank', 'menubar=no,toolbar=no,location=no,resizable=yes,scrollbars=yes,personalbar=no,chrome=yes,height=700,width=980');
+function disableClicks(){
+(function ($) {
+$('body', newWindow.document).addClass('newwindow');
+$('body', newWindow.document).delegate('a', 'click', function () {
+if($(this).hasClass('showHide'))
+return true;
+else
+return false;
+});
+}(jQuery));
+}
+if(newWindow.addEventListener){
+newWindow.addEventListener('load',disableClicks)
+} else if (newWindow.attachEvent){
+newWindow.attachEvent('onload',disableClicks);
+}
+}
 </function>

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/nycha_spending/charts/nycha_spending_visual_2.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/nycha_spending/charts/nycha_spending_visual_2.json
@@ -66,7 +66,8 @@ foreach($node->data as $row){
 $tooltip_label =
 'Vendor: ' . $row['vendor_name'] .'<br/>' .
 'Amount: ' . custom_number_formatter_format($row['check_amount_sum'] ,2, '$').  '<br/>';
-$link =  strstr($_GET['q'],'/',true) .  NychaContractsUrlService::generateLandingPageUrl('vendor', $row['vendor_id']) .'?expandBottomCont=true';
+//$link =  strstr($_GET['q'],'/',true) .  NychaContractsUrlService::generateLandingPageUrl('vendor', $row['vendor_id']) .'?expandBottomCont=true';
+$link = strstr($_GET['q'],'/',true) . NychaSpendingUrlService::generateLandingPageUrl('vendor',$row['vendor_id']);
 $series_new[$index]->url = 	$link;
 $series_new[$index]->y = (float)$row['check_amount_sum'];
 $series_new[$index]->tooltip_label = $tooltip_label;

--- a/source/webapp/sites/all/modules/custom/checkbook_widget_redesign/checkbook_business_layer/checkbook_services/nychaSpending/NychaSpendingWidgetService.php
+++ b/source/webapp/sites/all/modules/custom/checkbook_widget_redesign/checkbook_business_layer/checkbook_services/nychaSpending/NychaSpendingWidgetService.php
@@ -23,7 +23,7 @@ class NychaSpendingWidgetService extends WidgetDataService implements IWidgetSer
                 $contract_id = isset($row['contract_id']) && $row['contract_id'] ? $row['contract_id']: $row['purchase_order_number'];
                 $year_id = RequestUtilities::getRequestParamValue('year');
                 $class = "new_window";
-                $url ='/nycha_contract_details' . '/year/'.$year_id.$year_id.'/contract/' . $contract_id .'/newwindow';
+                $url ='/nycha_contract_details' . '/year/'.$year_id.'/contract/' . $contract_id .'/newwindow';
                 $value = "<a class='{$class}' href='{$url}'>{$contract_id}</a>";
                 break;
             case "industry_link":


### PR DESCRIPTION
Updated links for nycha spending visualizations vendor and contract id links.
Contract id opens in new window and shows contract details.
Vendor id filters data for particular id and chart is not displayed for vendor id.
Updated the drupal configurations to show the correct charts for the category choosen. Please build and verify.
