### PR TITLE
 Document id display issue narrow down filters in firefox  fix

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_faceted_search/css/narrow-down-filter.css
+++ b/source/webapp/sites/all/modules/custom/checkbook_faceted_search/css/narrow-down-filter.css
@@ -138,6 +138,7 @@ div.filter-content-fdomainName div.options{
     max-width: 110px;
     text-transform: uppercase;
     cursor: pointer;
+    word-break: break-word;
 }
 .grid-3 div.number,
 .page-node div.number,


### PR DESCRIPTION
Tested in both chrome and firefox.