### PR TITLE
NYCCHKBK-9647: Removed like search for PIN filter as 'po_header_heade…

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_api/config/contracts_nycha.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_api/config/contracts_nycha.json
@@ -23,7 +23,7 @@
       "sortColumn":["sort_sequence"],
       "columnTypes":{
         "contract_id":"like",
-        "po_header_id": "like",
+        //"po_header_id": "like",
         "vendor_name":"contains",
         "purpose":"contains"
       },


### PR DESCRIPTION
…r' is defined as integer.