### PR TITLE
Feature/nycchkbk 9257 - Payroll - hourly and daily rate display for citywide and nycha.

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/payroll/transaction_page_widgets/310.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/payroll/transaction_page_widgets/310.json
@@ -38,14 +38,14 @@
       "civil_service_title.civil_service_title", "annual_salary.annual_salary","amount_basis_id.amount_basis_id",
       "payroll_type", "pay_frequency.pay_frequency", "pay_date.pay_date","gross_pay.gross_pay","base_pay.base_pay",
       "other_payments.other_payments", "overtime_pay.overtime_pay","gross_pay_ytd.gross_pay_ytd",
-      "fiscal_year_id.fiscal_year_id","agency_id.agency_id", "hourly_rate.hourly_rate"],
+      "fiscal_year_id.fiscal_year_id","agency_id.agency_id", "hourly_rate.hourly_rate","daily_wage.daily_wage"],
     "caption":"",
     "derivedColumns": {
         "formatted_annual_salary": {
             "expression": "$row['amount_basis_id_amount_basis_id'] == 1 ? custom_number_formatter_basic_format($row['annual_salary_annual_salary'])  : '-'"
         },
         "formatted_hourly_rate": {
-            "expression":" $row['amount_basis_id_amount_basis_id'] != 1 ? custom_number_formatter_basic_format($row['hourly_rate_hourly_rate'])  : '-'"
+        "expression":" $row['amount_basis_id_amount_basis_id'] != 1 ? ((isset($row['hourly_rate_hourly_rate']) && $row['hourly_rate_hourly_rate'] > 0) ? custom_number_formatter_basic_format($row['hourly_rate_hourly_rate'])  : ((isset($row['daily_wage_daily_wage']) && $row['daily_wage_daily_wage'] > 0) ? custom_number_formatter_basic_format($row['daily_wage_daily_wage']) : '-')): '-' "
         },
         "formatted_gross_pay_amount": {
             "expression": "custom_number_formatter_basic_format($row['gross_pay_gross_pay'])"

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/payroll/transaction_page_widgets/317.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/payroll/transaction_page_widgets/317.json
@@ -45,7 +45,8 @@
     "columns": ["agency.agency", "agency.agency.agency_short_name", "agency.agency.agency_name", "pay_date.pay_date",
                 "civil_service_title.civil_service_title","civil_service_title_code.civil_service_title_code", "year_type.year_type", "year.year",
                 "employee.employee", "employee_number.employee_number", "employment_type.employment_type", "max_hourly_rate", "max_daily_wage",
-                "total_salaried_amount","total_non_salaried_amount","total_gross_pay","total_base_salary","total_other_payments","total_overtime_amount"],
+                "max_hourly_daily","total_salaried_amount","total_non_salaried_amount","total_gross_pay","total_base_salary",
+                "total_other_payments","total_overtime_amount"],
     "derivedColumns": {
         "employee_name_formatted": {
           "expression": "_get_tooltip_markup($row['civil_service_title_civil_service_title'],30)"
@@ -57,10 +58,10 @@
           "expression": "_get_tooltip_markup($row['agency_agency_agency_name'],30)"
         },
         "formatted_salary_amount": {
-          "expression": " (isset($row['total_salaried_amount']) && $row['total_salaried_amount'] > 0) ? custom_number_formatter_basic_format($row['total_salaried_amount'])  : '-'  "
+          "expression": " isset($row['total_salaried_amount']) ? custom_number_formatter_basic_format($row['total_salaried_amount'])  : '-'  "
         },
         "annual_salary_link": {
-          "expression": "(isset($row['formatted_salary_amount']) && $row['formatted_salary_amount'] != '-') ? '<a class =\"bottomContainerReload\" href=/panel_html/payroll_employee_transactions/payroll/employee/transactions/agency/' . $row['agency_agency'] . _checkbook_project_get_year_url_param_string() . RequestUtilities::_getUrlParamString('datasource') . '/salamttype/1/abc/' . $row['employee_employee'] . '>'. $row['formatted_salary_amount'] .'</a>' : '-'"
+          "expression": "isset($row['total_salaried_amount']) ? '<a class =\"bottomContainerReload\" href=/panel_html/payroll_employee_transactions/payroll/employee/transactions/agency/' . $row['agency_agency'] . _checkbook_project_get_year_url_param_string() . RequestUtilities::_getUrlParamString('datasource') . '/salamttype/1/abc/' . $row['employee_employee'] . '>'. $row['formatted_salary_amount'] .'</a>' : '-'"
         },
         "formatted_non_salary_amount": {
           "expression": " isset($row['total_non_salaried_amount']) ? custom_number_formatter_basic_format($row['total_non_salaried_amount']) : '-'"
@@ -72,7 +73,7 @@
           "expression": " isset($row['max_daily_wage']) ? custom_number_formatter_basic_format($row['max_daily_wage']) : '-'"
         },
         "formatted_hourly_rate_amount": {
-          "expression": " (isset($row['max_hourly_rate']) && $row['max_hourly_rate'] > 0) ? custom_number_formatter_basic_format($row['max_hourly_rate']) : ((isset($row['max_daily_wage']) && $row['max_daily_wage'] > 0) ? custom_number_formatter_basic_format($row['max_daily_wage']) : '-')"
+          "expression": " isset($row['max_hourly_rate']) ? custom_number_formatter_basic_format($row['max_hourly_rate']) : '-'"
         },
         "daily_wage_link": {
           "expression": " isset($row['max_daily_wage']) ? '<a class =\"bottomContainerReload\" href=/panel_html/payroll_employee_transactions/payroll/employee/transactions/agency/' . $row['agency_agency'] . _checkbook_project_get_year_url_param_string() . RequestUtilities::_getUrlParamString('datasource')  . '/salamttype/2~3/abc/' . $row['employee_employee'] . '>'. $row['formatted_daily_wage_amount'] .'</a>' : '-'"
@@ -82,7 +83,10 @@
           "expression": " (isset($row['max_daily_wage']) && $row['max_daily_wage'] > 0) ? $row['daily_wage_link'] : '-'"
         },
         "hourly_rate_link": {
-          "expression": " (isset($row['formatted_hourly_rate_amount']) && $row['formatted_hourly_rate_amount'] != '-') ? '<a class =\"bottomContainerReload\" href=/panel_html/payroll_employee_transactions/payroll/employee/transactions/agency/' . $row['agency_agency'] . _checkbook_project_get_year_url_param_string() . RequestUtilities::_getUrlParamString('datasource')  . '/salamttype/2~3/abc/' . $row['employee_employee'] . '>'. $row['formatted_hourly_rate_amount'] .'</a>' : '-'"
+          "expression": " isset($row['max_hourly_rate']) ? '<a class =\"bottomContainerReload\" href=/panel_html/payroll_employee_transactions/payroll/employee/transactions/agency/' . $row['agency_agency'] . _checkbook_project_get_year_url_param_string() . RequestUtilities::_getUrlParamString('datasource')  . '/salamttype/2~3/abc/' . $row['employee_employee'] . '>'. $row['formatted_hourly_rate_amount'] .'</a>' : '-'"
+        },
+        "hourly_daily_link": {
+        "expression": " (isset($row['max_hourly_daily']) && $row['max_hourly_daily'] != '-') ? '<a class =\"bottomContainerReload\" href=/panel_html/payroll_employee_transactions/payroll/employee/transactions/agency/' . $row['agency_agency'] . _checkbook_project_get_year_url_param_string() . RequestUtilities::_getUrlParamString('datasource')  . '/salamttype/2~3/abc/' . $row['employee_employee'] . '>'. $row['max_hourly_daily'] .'</a>' : '-'"
         },
         //NYCHA Hourly Rate Link - Show hyphen when the amount is zero
         "nycha_hourly_rate_link": {
@@ -117,7 +121,7 @@
             {"labelAlias": "title","column": "employee_name_formatted","sortSourceColumn":"civil_service_title.civil_service_title"},
             {"labelAlias": "agency_name","column":"agency_name_formatted","sortSourceColumn":"agency.agency.agency_name"},
             {"labelAlias": "annual_salary","column": "annual_salary_link","sortSourceColumn": "total_salaried_amount"},
-            {"labelAlias": "hourly_rate","column": "hourly_rate_link","sortSourceColumn": "max_hourly_rate"},
+            {"labelAlias": "hourly_rate","column": "hourly_daily_link","sortSourceColumn": "max_hourly_daily"},
             {"labelAlias": "daily_wage","column": "daily_wage_link","sortSourceColumn": "max_daily_wage"},
             {"labelAlias": "gross_pay_ytd","column": "formatted_gross_pay_amount","sortSourceColumn": "total_gross_pay"},
             {"labelAlias": "base_pay","column": "formatted_base_salary_amount","sortSourceColumn": "total_base_salary"},
@@ -141,6 +145,7 @@
             //hourly rate column for nycha
             if(($table_column->labelAlias == 'hourly_rate' )&& ($datasource=='checkbook_nycha' )){
                 $table_column->column= 'nycha_hourly_rate_link';
+                $table_column->sortSource= 'max_hourly_rate';
            }
             //daily wage column must be sorted by default for nycha
             if($table_column->labelAlias == 'daily_wage' && ($datasource=='checkbook_nycha' ) ){

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/payroll/transaction_page_widgets/330.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/payroll/transaction_page_widgets/330.json
@@ -32,24 +32,31 @@
     "html_class": "initiative-table",
     "no_results_content":"No Results Found",
     "dataset": "checkbook:payroll",
-    "columns": ["employee_number.employee_number","payroll_id.payroll_id","agency_name.agency_name","civil_service_title.civil_service_title","annual_salary.annual_salary",
+    "preProcessConfiguration":"
+    $datasource = RequestUtilities::getRequestParamValue('datasource');
+    if($datasource=='checkbook_nycha'){
+    $node->widgetConfig->dataset='checkbook_nycha:payroll';
+    }
+    ",
+    "columns": ["employee_number.employee_number","payroll_id.payroll_id","agency_name.agency_name","civil_service_title.civil_service_title","annual_salary_pay","annual_salary.annual_salary",
       "amount_basis_id.amount_basis_id","payroll_type","pay_frequency.pay_frequency","pay_date.pay_date",
       "gross_pay.gross_pay","base_pay.base_pay","other_payments.other_payments","overtime_pay.overtime_pay",
       "gross_pay_cytd.gross_pay_cytd","calendar_fiscal_year_id.calendar_fiscal_year_id","agency_id.agency_id",
+      "hourly_rate_amount","daily_wage_pay",
       "hourly_rate.hourly_rate","daily_wage.daily_wage"],
     "caption":"",
     "derivedColumns": {
-        "formatted_daily_wage_amount": {
-          "expression": "$row['amount_basis_id_amount_basis_id'] == 2 ? custom_number_formatter_basic_format($row['daily_wage_daily_wage'])  : '-'"
+        "formatted_daily_wage_pay": {
+          "expression": "$row['daily_wage_pay'] == NULL ? '-' : custom_number_formatter_basic_format($row['daily_wage_pay'])"
         },
-        "formatted_annual_salary": {
-        "expression": "$row['amount_basis_id_amount_basis_id'] == 1 ? custom_number_formatter_basic_format($row['annual_salary_annual_salary'])  : '-'"
+        "formatted_annual_salary_pay": {
+        "expression": "$row['annual_salary_pay'] == NULL ? '-' : custom_number_formatter_basic_format($row['annual_salary_pay'])"
         },
-      "formatted_hourly_rate": {
-        "expression":" (isset($row['hourly_rate_hourly_rate']) && $row['hourly_rate_hourly_rate'] > 0) ? custom_number_formatter_basic_format($row['hourly_rate_hourly_rate'])  : ((isset($row['daily_wage_daily_wage']) && $row['daily_wage_daily_wage'] > 0) ? custom_number_formatter_basic_format($row['daily_wage_daily_wage']) : '-') "
+      "formatted_hourly_rate_amount": {
+        "expression": "$row['hourly_rate_amount'] == NULL ? '-' : custom_number_formatter_basic_format($row['hourly_rate_amount'])"
       },
         "nycha_hourly_rate":{
-          "expression":"(isset($row['hourly_rate_hourly_rate']) && $row['hourly_rate_hourly_rate'] > 0) ? custom_number_formatter_basic_format($row['hourly_rate_hourly_rate'])  : '-'"
+          "expression": "$row['hourly_rate_amount'] == NULL ? '-' : custom_number_formatter_basic_format($row['hourly_rate_amount'])"
         },
         "formatted_gross_pay_amount": {
         "expression": "custom_number_formatter_basic_format($row['gross_pay_gross_pay'])"
@@ -89,9 +96,9 @@
             {"labelAlias": "title","column": "title_name_formatted","sortSourceColumn": "civil_service_title.civil_service_title"},
             {"labelAlias": "agency_name","column": "agency_name_formatted","sortSourceColumn": "agency_name.agency_name"},
             {"labelAlias": "pay_date","column":"pay_date_formatted",  "sortSourceColumn":"pay_date.pay_date"},
-            {"labelAlias": "annual_salary","column": "formatted_annual_salary","sortSourceColumn": "annual_salary.annual_salary"},
-            {"labelAlias": "hourly_rate","column": "formatted_hourly_rate","sortSourceColumn": "hourly_rate.hourly_rate"},
-            {"labelAlias": "daily_wage","column": "formatted_daily_wage_amount","sortSourceColumn": "daily_wage.daily_wage"},
+            {"labelAlias": "annual_salary","column": "formatted_annual_salary_pay","sortSourceColumn": "annual_salary_pay"},
+            {"labelAlias": "hourly_rate","column": "formatted_hourly_rate_amount","sortSourceColumn": "hourly_rate_amount"},
+            {"labelAlias": "daily_wage","column": "formatted_daily_wage_pay","sortSourceColumn": "daily_wage_pay"},
             {"labelAlias": "pay_frequency","column": "pay_frequency_formatted","sortSourceColumn":"pay_frequency.pay_frequency"},
             {"labelAlias": "gross_pay","column": "formatted_gross_pay_amount","sortSourceColumn": "gross_pay.gross_pay"},
             {"labelAlias": "base_pay","column": "formatted_base_pay_amount","sortSourceColumn": "base_pay.base_pay"},

--- a/source/webapp/sites/all/modules/custom/checkbook_smart_search/templates/payroll.tpl.php
+++ b/source/webapp/sites/all/modules/custom/checkbook_smart_search/templates/payroll.tpl.php
@@ -51,6 +51,9 @@ switch($solr_datasource){
     break;
   default:
     $yeartype="B";
+    if ($payroll_results['payroll_type_text'][0] == 'NON-SALARIED' && $payroll_results['hourly_rate'] == 0){
+      $payroll_results['hourly_rate'] = $payroll_results['daily_wage'];
+    }
     $linkable_fields = [
       "agency_name" => "/payroll/agency_landing/yeartype/C/year/" . $fiscal_year_id . "/agency/" . $agency_id,
     ];
@@ -94,7 +97,7 @@ foreach ($payroll_parameter_mapping as $key => $title){
         .$agency_id . $dataSourceUrl . "/abc/" .$emp_id. "/salamttype/".$salaried."/year/"
         . $fiscal_year_id . "/yeartype/".$yeartype."'>". custom_number_formatter_format($value, 2 , '$') ."</a>";
     } else {
-      $value = '';
+      $value = '-';
     }
   }
 

--- a/source/webapp/sites/all/modules/custom/dashboard_platform/checkbook_metamodel/metamodel/metadata/checkbook/cube-payroll.json
+++ b/source/webapp/sites/all/modules/custom/dashboard_platform/checkbook_metamodel/metamodel/metadata/checkbook/cube-payroll.json
@@ -221,8 +221,8 @@
                 "payroll_type": {
                     "function": "MAX(CASE WHEN amount_basis_id = 1 THEN 'Salaried' ELSE 'Non-Salaried' END)"
                 },
-                /*"annual_salary_pay":{
-                    "function": "CASE WHEN amount_basis_id = 1 THEN annual_salary ELSE NULL END"
+                "annual_salary_pay":{
+                  "function": "CASE WHEN amount_basis_id = 1 AND annual_salary > 0 THEN cast(annual_salary as text) ELSE '-' END"
                 },
                 "hourly_rate_pay":{
                     "function": "CASE WHEN amount_basis_id = 1 THEN NULL ELSE annual_salary END"
@@ -234,8 +234,8 @@
                     "function": "CASE WHEN amount_basis_id = 2 THEN annual_salary ELSE NULL END"
                 },
                 "hourly_rate_amount":{
-                    "function": "CASE WHEN amount_basis_id = 3 THEN  annual_salary ELSE NULL END"
-                },*/
+                    "function": "CASE WHEN hourly_rate > 0 THEN cast(hourly_rate as text ) WHEN daily_wage > 0 THEN cast(daily_wage as text) ELSE '-' END"
+                },
                 "total_gross_pay": {
                     "function": "SUM(gross_pay)"
                 },

--- a/source/webapp/sites/all/modules/custom/dashboard_platform/checkbook_metamodel/metamodel/metadata/checkbook/cube-payroll_employee_agency.json
+++ b/source/webapp/sites/all/modules/custom/dashboard_platform/checkbook_metamodel/metamodel/metadata/checkbook/cube-payroll_employee_agency.json
@@ -173,7 +173,7 @@
                     "function": "SUM(annual_salary)"
                 },
                 "total_salaried_amount": {
-                    "function": "SUM( CASE WHEN type_of_employment = 'Salaried' THEN COALESCE(annual_salary,0) else NULL END)"
+                    "function": "(CASE WHEN type_of_employment = 'Salaried' AND SUM(COALESCE(annual_salary,0)) > 0 THEN CAST(SUM(COALESCE(annual_salary,0)) AS varchar) else CAST('-' AS varchar) END)"
                 },
                 "total_salaried_employees": {
                     "function": "COUNT(DISTINCT (CASE WHEN type_of_employment = 'Salaried' THEN employee_number END))"
@@ -191,10 +191,13 @@
                     "function": "SUM( CASE WHEN type_of_employment = 'Salaried' THEN NULL else COALESCE(annual_salary,0) END)"
                 },
                 "max_hourly_rate":{
-                  "function": "MAX(hourly_rate)"
+                  "function": "MAX(CASE WHEN hourly_rate > 0 THEN CAST(hourly_rate AS varchar) else CAST('-' as varchar) END)"
                 },
                 "max_daily_wage":{
-                  "function": "MAX(daily_wage)"
+                  "function": "MAX(CASE WHEN daily_wage > 0 THEN CAST (daily_wage AS varchar) else CAST('-' as varchar) END)"
+                },
+                "max_hourly_daily":{
+                "function": "(CASE WHEN MAX(daily_wage) > 0 THEN CAST(MAX(daily_wage) AS VARCHAR)  WHEN MAX(hourly_rate) > 0 THEN CAST(MAX(hourly_rate) AS VARCHAR) ELSE CAST('-' as varchar) END)"
                 },
                 "total_overtime_employees": {
                     "function": "COUNT(DISTINCT (CASE WHEN COALESCE(positive_overtime_pay,0) > 0 THEN employee_number END))"

--- a/source/webapp/sites/all/modules/custom/dashboard_platform/checkbook_metamodel/metamodel/metadata/checkbook_nycha/cube-payroll.json
+++ b/source/webapp/sites/all/modules/custom/dashboard_platform/checkbook_metamodel/metamodel/metadata/checkbook_nycha/cube-payroll.json
@@ -233,18 +233,18 @@
                 "rate_type": {
                     "function": "MAX(CASE WHEN amount_basis_id = 2 THEN 'Daily' WHEN amount_basis_id = 3 Then 'Hourly' Else 'Annual'END)"
                 },
-                /*"annual_salary_pay":{
-                    "function": "CASE WHEN amount_basis_id = 1 THEN annual_salary ELSE NULL END"
+                "annual_salary_pay":{
+                    "function": "CASE WHEN amount_basis_id = 1 AND annual_salary > 0 THEN cast(annual_salary as text) ELSE '-' END"
                 },
                 "hourly_rate_pay":{
                     "function": "CASE WHEN amount_basis_id = 1 THEN NULL ELSE annual_salary END"
                 },
                 "daily_wage_pay":{
-                    "function": "CASE WHEN amount_basis_id = 2 THEN annual_salary ELSE NULL END"
+                    "function": "CASE WHEN amount_basis_id != 1 AND daily_wage > 0 THEN cast(daily_wage as text) ELSE '-' END"
                 },
                 "hourly_rate_amount":{
-                    "function": "CASE WHEN amount_basis_id = 3 THEN  annual_salary ELSE NULL END"
-                },*/
+                    "function": "CASE WHEN amount_basis_id != 1 AND hourly_rate > 0  THEN cast(hourly_rate as text)  ELSE '-' END"
+                },
                 "max_annual_salary":{
                     "function": "MAX(annual_salary)"
                 },

--- a/source/webapp/sites/all/modules/custom/dashboard_platform/checkbook_metamodel/metamodel/metadata/checkbook_nycha/cube-payroll_employee_agency_basis.json
+++ b/source/webapp/sites/all/modules/custom/dashboard_platform/checkbook_metamodel/metamodel/metadata/checkbook_nycha/cube-payroll_employee_agency_basis.json
@@ -183,7 +183,7 @@
           "function": "SUM(annual_salary)"
         },
         "total_salaried_amount": {
-          "function": "SUM( CASE WHEN type_of_employment = 'Salaried' THEN COALESCE(annual_salary,0) else NULL END)"
+          "function": "(CASE WHEN type_of_employment = 'Salaried' AND SUM(COALESCE(annual_salary,0)) > 0 THEN CAST(SUM(COALESCE(annual_salary,0)) AS varchar) else CAST('-' AS varchar) END)"
         },
         "total_salaried_employees": {
           "function": "COUNT(DISTINCT (CASE WHEN type_of_employment = 'Salaried' THEN employee_number END))"
@@ -210,10 +210,13 @@
           "function": "MAX(annual_salary)"
         },
         "max_hourly_rate":{
-          "function": "MAX(hourly_rate)"
+          "function": "MAX(CASE WHEN hourly_rate > 0 THEN CAST(hourly_rate AS varchar) else CAST('-' as varchar) END)"
         },
         "max_daily_wage":{
-          "function": "MAX(daily_wage)"
+          "function": "MAX(CASE WHEN daily_wage > 0 THEN CAST (daily_wage AS varchar) else CAST('-' as varchar) END)"
+        },
+        "max_hourly_daily":{
+          "function": "(CASE WHEN MAX(hourly_rate) > 0 THEN CAST(MAX(hourly_rate) AS VARCHAR) ELSE CAST('-' as varchar) END)"
         },
         "total_gross_pay": {
           "function": "SUM(gross_pay)"


### PR DESCRIPTION
Payroll - Citywide 
1) Hourly and daily is show in the one column. When both hourly and daily data is null  or data is less than zero display '-' in both transactions and exports.
2) Smart search display also modified to show above change.
3) All the related pages also verified and updated accordingly.

Payroll Nycha
1) hourly and daily data is shown in 2 separate columns. Display hyphen when there is null data or data is less than 0. Export also dispay accordingly.
2) Verified the related pages and updated accordingly.