### PR TITLE
Feature/nycchkbk 9491 - Vendor name 'n/a' disabled in transation page filter display. 'N/A' to appear in transaction pages and widgets and not linkable.

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_faceted_search/individual-filter.tpl.php
+++ b/source/webapp/sites/all/modules/custom/checkbook_faceted_search/individual-filter.tpl.php
@@ -64,23 +64,6 @@ if($node->widgetConfig->filterName == 'Amount') {
     }
 }
 
-//Vendor Filter (NYCCHKBK-9825 - for nycha spending vendor name N/A appears as null the below code will fix the issue.)
-if($node->widgetConfig->filterName == 'Vendor') {
-  if ($unchecked && $unchecked)
-    foreach($unchecked as $key => $value) {
-      if($value[1] == null) {
-        $unchecked[$key][0] = "N/A";
-        $unchecked[$key][1] = "N/A";
-      }
-    }
-  if (isset($checked) && $checked)
-    foreach($checked as $key => $value) {
-      if($value[1] == null) {
-        $checked[$key][0] = "N/A";
-        $checked[$key][1] = "N/A";
-      }
-    }
-}
 //Payroll Range Filter
 $is_payroll_range_filter =
     ($node->widgetConfig->filterName == 'Gross Pay YTD') ||

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/nycha_spending/advanced_search_facets/1031.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/nycha_spending/advanced_search_facets/1031.json
@@ -21,6 +21,7 @@
   $adjustedParameters = _checkbook_project_applyParameterFilters($node,$parameters);
 }
 $adjustedParameters['vendor_name.vendor_name'][] = data_controller_get_operator_factory_instance()->initiateHandler(NotEmptyOperatorHandler::$OPERATOR__NAME);
+$adjustedParameters['vendor_customer_code.vendor_customer_code'][] = data_controller_get_operator_factory_instance()->initiateHandler(NotEmptyOperatorHandler::$OPERATOR__NAME);
 return $adjustedParameters;
 ",
 "template":"individual_filter"

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/nycha_spending/transactions_page_widgets/1018.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/nycha_spending/transactions_page_widgets/1018.json
@@ -6,7 +6,7 @@
   "startWith":0,
   "maxSelect":5,
   "showAllRecords":true,
-  "columns":["vendor_id.vendor_id","vendor_name.vendor_name","txcount"],
+  "columns":["vendor_id.vendor_id","vendor_name.vendor_name","txcount","vendor_customer_code.vendor_customer_code"],
   "orderBy":"-txcount",
   "facetPager":true,
   "filterName":"Vendor",
@@ -15,10 +15,13 @@
   "autocompleteID":"fvendorId",
   "autocompleteField":"vendor_name",
   "adjustParameters":"
+
       if(function_exists('_checkbook_project_applyParameterFilters')){
         $adjustedParameters = _checkbook_project_applyParameterFilters($node,$parameters);
       }
+
       $adjustedParameters['vendor_id.vendor_id'][] = data_controller_get_operator_factory_instance()->initiateHandler(NotEmptyOperatorHandler::$OPERATOR__NAME);
+      $adjustedParameters['vendor_customer_code.vendor_customer_code'][] = data_controller_get_operator_factory_instance()->initiateHandler(NotEmptyOperatorHandler::$OPERATOR__NAME);
       return $adjustedParameters;
   ",
   "adjustFacetOptions":"

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/nycha_spending/transactions_page_widgets/1018.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/nycha_spending/transactions_page_widgets/1018.json
@@ -6,7 +6,7 @@
   "startWith":0,
   "maxSelect":5,
   "showAllRecords":true,
-  "columns":["vendor_id.vendor_id","vendor_name.vendor_name","txcount","vendor_customer_code.vendor_customer_code"],
+  "columns":["vendor_id.vendor_id","vendor_name.vendor_name","txcount"],
   "orderBy":"-txcount",
   "facetPager":true,
   "filterName":"Vendor",

--- a/source/webapp/sites/all/modules/custom/dashboard_platform/checkbook_metamodel/metamodel/metadata/checkbook_nycha/cube-nycha_spending_transactions.json
+++ b/source/webapp/sites/all/modules/custom/dashboard_platform/checkbook_metamodel/metamodel/metadata/checkbook_nycha/cube-nycha_spending_transactions.json
@@ -117,6 +117,15 @@
           ]
         },
         {
+          "name": "vendor_customer_code",
+          "levels": [
+            {
+              "name": "vendor_customer_code",
+              "sourceColumnName": "vendor_customer_code"
+            }
+          ]
+        },
+        {
           "name": "vendor_name",
           "levels": [
             {


### PR DESCRIPTION
Vendor name 'n/a' does not have a vendor customer code associated with it but has a vendor id. Hence filter facets display vendor data with id and code not equal to null. Verified nycha widget , spending transactions and advanced transactions.