### PR TITLE
NYCCHKBK-9596: NYCHA auto-complete mapping for vendor

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_solr/config/nycha.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_solr/config/nycha.json
@@ -275,7 +275,7 @@
     }
   },
   "autocomplete_terms": {
-    "vendor_name": "Vendors",
+    "vendor_name_search": "Vendors",
     "contract_number": "Contract ID",
     "grant_name": "Grant Name",
     "funding_source_name": "Funding Source",


### PR DESCRIPTION
Vendor name auto-complete (main search bar) should be mapped with 'vendor_name_search' Solr field as N/A changes are implemented in it.