### PR TITLE
Feature/nycchkbk 9920 - Advanced search results for terms with space.

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_project/customclasses/RequestUtil.php
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/customclasses/RequestUtil.php
@@ -1019,5 +1019,17 @@ class RequestUtil
     return $setAutoDeselect;
   }
 
+  /** Checks if the URL is advanced  autocomplete url */
+  public static function isAdvancedAutocompleteLinks()
+  {
+    $pageType = $_GET['q'];
+    $isAdvancedAuto = 0;
+    if (preg_match('/^advanced_autocomplete/', $pageType)) {
+      $isAdvancedAuto = 1;
+    }
+    return $isAdvancedAuto;
+
+  }
+
 }
 

--- a/source/webapp/sites/all/modules/custom/checkbook_solr/src/checkbook_solr_query.class.inc
+++ b/source/webapp/sites/all/modules/custom/checkbook_solr/src/checkbook_solr_query.class.inc
@@ -498,6 +498,12 @@ class CheckbookSolrQuery
    */
   public function setFqAutocompleteTerm(string $facet, string $term): CheckbookSolrQuery
   {
+    # Fix for NYCCHKBK-9920 term with space displays all the results for autocomplete in advanced search
+    # Check if the link is advanced search autocompletes and trim trailing space to display correct results
+    $setAdvancedAuto= RequestUtil::isAdvancedAutocompleteLinks();
+    if ($setAdvancedAuto == 1){
+      $term = trim($term);
+    }
     $term = htmlspecialchars_decode($term, ENT_QUOTES);
     $this->mapParam($facet);
     $autoCompleteFacet = $this->autocompleteMapping[$facet] ?? $facet;


### PR DESCRIPTION
The issue is 801ge without space gives correct results, but add a space to the term it shows all the results. This issue only exist in advanced search. Data-feeds looks fine for both the scenario. 