### PR TITLE
Reduce left margin of first column heading in transaction data tables

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/nycha_revenue/transactions_page_widgets/1051.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/nycha_revenue/transactions_page_widgets/1051.json
@@ -225,7 +225,7 @@ $node->widgetConfig->dataTableOptions->aaSorting[0][0] = 4;
 },
 "bInfo": true,
 "aoColumns":[
-{"sClass":"text nycha-revenue-transaction","sWidth":"70px","asSorting": [ "desc","asc" ]},
+{"sClass":"text","sWidth":"70px","asSorting": [ "desc","asc" ]},
 {"sClass":"number","sWidth":"135px","asSorting": [ "desc","asc" ]},
 {"sClass":"number","sWidth":"135px","asSorting": [ "desc","asc" ]},
 {"sClass":"number", "sWidth":"135px","asSorting": [ "asc","desc" ]},

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/nycha_revenue/transactions_page_widgets/1051.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/nycha_revenue/transactions_page_widgets/1051.json
@@ -225,7 +225,7 @@ $node->widgetConfig->dataTableOptions->aaSorting[0][0] = 4;
 },
 "bInfo": true,
 "aoColumns":[
-{"sClass":"text","sWidth":"70px","asSorting": [ "desc","asc" ]},
+{"sClass":"text nycha-revenue-transaction","sWidth":"70px","asSorting": [ "desc","asc" ]},
 {"sClass":"number","sWidth":"135px","asSorting": [ "desc","asc" ]},
 {"sClass":"number","sWidth":"135px","asSorting": [ "desc","asc" ]},
 {"sClass":"number", "sWidth":"135px","asSorting": [ "asc","desc" ]},

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/nycha_revenue/transactions_page_widgets/1051.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/nycha_revenue/transactions_page_widgets/1051.json
@@ -248,7 +248,7 @@ $node->widgetConfig->dataTableOptions->aaSorting[0][0] = 4;
 "bScrollCollapse": false,
 "fnInitComplete": "##function () { new FixedColumns( oTable, {
 \"iLeftColumns\": 1,
-\"iLeftWidth\": 115
+\"iLeftWidth\": 120
 } );}##"
 },
 "customExternalJS":"function prepareTableListFilterUrl(){

--- a/source/webapp/sites/all/themes/checkbook3/css/global.css
+++ b/source/webapp/sites/all/themes/checkbook3/css/global.css
@@ -1875,6 +1875,11 @@ table.dataTable th.sorting_asc span {
 .dataTable th:first-child div {
     margin: 8px 0 8px 15px;
 }
+
+.initiative-table.dataTable th:first-child div{
+    margin: 8px 0 8px 10px;
+}
+
 .dataTable td.text:first-child div {
     margin: 13px 0 13px 15px;
 }

--- a/source/webapp/sites/all/themes/checkbook3/css/global.css
+++ b/source/webapp/sites/all/themes/checkbook3/css/global.css
@@ -1876,8 +1876,9 @@ table.dataTable th.sorting_asc span {
     margin: 8px 0 8px 15px;
 }
 
-.initiative-table.dataTable th:first-child div{
-    margin: 8px 0 8px 10px;
+/*Only applicable to nycha revenue transaction pages*/
+.dataTable th:first-child.nycha-revenue-transaction div{
+    margin: 8px 0 8px 3px;
 }
 
 .dataTable td.text:first-child div {
@@ -4135,3 +4136,4 @@ body.page-data-feeds #div_data_source,
 #checkbook-advanced-search-form .data_source-label{
   font-weight: bold;
 }
+

--- a/source/webapp/sites/all/themes/checkbook3/css/global.css
+++ b/source/webapp/sites/all/themes/checkbook3/css/global.css
@@ -1876,9 +1876,8 @@ table.dataTable th.sorting_asc span {
     margin: 8px 0 8px 15px;
 }
 
-/*Only applicable to nycha revenue transaction pages*/
-.dataTable th:first-child.nycha-revenue-transaction div{
-    margin: 8px 0 8px 3px;
+.initiative-table.dataTable th:first-child div{
+    margin: 8px 0 8px 10px;
 }
 
 .dataTable td.text:first-child div {
@@ -4136,4 +4135,3 @@ body.page-data-feeds #div_data_source,
 #checkbook-advanced-search-form .data_source-label{
   font-weight: bold;
 }
-

--- a/source/webapp/sites/all/themes/checkbook3/css/global.css
+++ b/source/webapp/sites/all/themes/checkbook3/css/global.css
@@ -1875,11 +1875,6 @@ table.dataTable th.sorting_asc span {
 .dataTable th:first-child div {
     margin: 8px 0 8px 15px;
 }
-
-.initiative-table.dataTable th:first-child div{
-    margin: 8px 0 8px 10px;
-}
-
 .dataTable td.text:first-child div {
     margin: 13px 0 13px 15px;
 }


### PR DESCRIPTION
Reduce left margin (from 15px to 10px) of first column heading for all transaction data tables. This is to fit two words in one line for the first column heading.