### PR TITLE
NYCCHKBK-9852: Self needs to used here as we want to fetch the data f…

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_widget_redesign/checkbook_business_layer/checkbook_services/common/data/DataService.php
+++ b/source/webapp/sites/all/modules/custom/checkbook_widget_redesign/checkbook_business_layer/checkbook_services/common/data/DataService.php
@@ -18,7 +18,7 @@ abstract class DataService implements IDataService {
      * @return DataService
      */
     public function configure($dataFunction, $parameters, $limit = null, $orderBy = null, $sqlConfigPath) {
-        return static::setDataFunction($dataFunction)
+        return self::setDataFunction($dataFunction)
             ->setSqlConfigPath($sqlConfigPath)
             ->setParameters($parameters)
             ->setLimit($limit)


### PR DESCRIPTION
…unction name in the same class.  static refers to the class in the hierarchy, where the method has been called (which is causing the issue when we have different data functions with same name like GetCountContracts)