### PR TITLE
Rectify the ID selector for capturing agency

### DIFF
--- a/source/webapp/sites/all/themes/checkbook3/js/advanced-search.js
+++ b/source/webapp/sites/all/themes/checkbook3/js/advanced-search.js
@@ -1027,7 +1027,7 @@
         if ('checkbook_nycha' == data_source) {
           solr_datasource = 'nycha';
         }else{
-          agency_id = $("edit-checkbook-payroll-agencies").val() || 0;
+          agency_id = $("#edit-checkbook-payroll-agencies").val() || 0;
         }
 
         var filters = {


### PR DESCRIPTION
Advanced Search Payroll section: Rectify the ID selector for capturing value of agency field (code) which acts a filter to fetch the list of keywords (for autocomplete) for 'Title' field.