### PR TITLE
Feature nycchkbk 10215 - Nycha budget - budget_name and budget_type factes and transactions page update.

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_datafeeds/checkbook_datafeeds.module
+++ b/source/webapp/sites/all/modules/custom/checkbook_datafeeds/checkbook_datafeeds.module
@@ -1140,7 +1140,8 @@ function _budget_type_options($domain, $dataSource = Datasource::CITYWIDE, $budg
   $budgetName = str_replace("__", "/", $budgetName);
   switch ($dataSource){
     case Datasource::NYCHA :
-      $where = (isset($budgetName) && !in_array($budgetName, array('Select Budget Name', '', 0, '0'), true)) ? "WHERE budget_name = '". $budgetName ."' ":"";
+      $where = "WHERE budget_type IS NOT NULL";
+      $where .= (isset($budgetName) && !in_array($budgetName, array('Select Budget Name', '', 0, '0'), true)) ? " AND budget_name = '". $budgetName ."' ":"";
       $query = "SELECT DISTINCT budget_type FROM {$domain} {$where} ORDER BY budget_type ASC";
       $data = _checkbook_project_execute_sql_by_data_source($query, $dataSource);
       $title = 'Select Budget Type';
@@ -1173,7 +1174,8 @@ function _budget_name_options($domain, $dataSource = Datasource::CITYWIDE, $budg
   $budgetType = str_replace("__", "/", $budgetType);
   switch ($dataSource){
     case Datasource::NYCHA :
-      $where = (isset($budgetType) && !in_array($budgetType, array('Select Budget Type', '', 0, '0'), true)) ? "WHERE budget_type = '". $budgetType ."' ":"";
+      $where = "WHERE budget_name IS NOT NULL";
+      $where .= (isset($budgetType) && !in_array($budgetType, array('Select Budget Type', '', 0, '0'), true)) ? " AND budget_type = '". $budgetType ."' ":"";
       $query = "SELECT DISTINCT budget_name FROM {$domain} {$where} ORDER BY budget_name ASC";
       $data = _checkbook_project_execute_sql_by_data_source($query, $dataSource);
       $title = 'Select Budget Name';

--- a/source/webapp/sites/all/modules/custom/checkbook_faceted_search/individual-filter.tpl.php
+++ b/source/webapp/sites/all/modules/custom/checkbook_faceted_search/individual-filter.tpl.php
@@ -142,8 +142,9 @@ if($node->widgetConfig->filterName == 'Document ID') {
     }
 }
 
-//Document ID filter display N/A for null values
-if($node->widgetConfig->filterName == 'Budget Name' || $node->widgetConfig->filterName == 'Budget Type') {
+//Budget Name and Budget Type filter display N/A values as N/A for Nycha budget and Nycha revenue fields
+if( $node->nid == '1043' || $node->nid == '1044' || $node->nid == '1059' || $node->nid == '1060')
+{
   if ($unchecked && $unchecked)
     foreach($unchecked as $key => $value) {
       if($value[1] == null ) {

--- a/source/webapp/sites/all/modules/custom/checkbook_project/customclasses/budget/NychaBudgetUtil.php
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/customclasses/budget/NychaBudgetUtil.php
@@ -123,4 +123,22 @@ class NychaBudgetUtil{
     return $query;
   }
 
+  // NYCCHKBK - 10215
+  // Requirement for Transactions Page results - budget_type and budget_name to display null as null and 'n/a' as 'n/a'
+  static public function getBudgetName($budgetId)
+  {
+    $where = "WHERE budget_id = '" . $budgetId . "' AND budget_name IS NOT NULL";
+    $query = "SELECT budget_name FROM budget {$where} ";
+    $data = _checkbook_project_execute_sql_by_data_source($query, 'checkbook_nycha');
+    $result = isset($data[0]['budget_name'])? $data[0]['budget_name'] : null;
+    return $result;
+  }
+  static public function getBudgetType($budgetId)
+  {
+    $where = "WHERE budget_id = '" . $budgetId . "' AND budget_type IS NOT NULL";
+    $query = "SELECT budget_type FROM budget {$where} ";
+    $data = _checkbook_project_execute_sql_by_data_source($query, 'checkbook_nycha');
+    $result = isset($data[0]['budget_type'])? $data[0]['budget_type'] : null;
+    return $result;
+  }
 }

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/narrow_down_filters/nycha_budget/1043.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/narrow_down_filters/nycha_budget/1043.json
@@ -19,6 +19,7 @@
     if(function_exists('_checkbook_project_applyParameterFilters')){
       $adjustedParameters = _checkbook_project_applyParameterFilters($node,$parameters);
      }
+    $adjustedParameters['budget_type.budget_type'][] = data_controller_get_operator_factory_instance()->initiateHandler(NotEmptyOperatorHandler::$OPERATOR__NAME);
     return $adjustedParameters;
   ",
   "template":"individual_filter"

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/narrow_down_filters/nycha_budget/1044.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/narrow_down_filters/nycha_budget/1044.json
@@ -19,6 +19,7 @@
     if(function_exists('_checkbook_project_applyParameterFilters')){
       $adjustedParameters = _checkbook_project_applyParameterFilters($node,$parameters);
     }
+    $adjustedParameters['budget_name.budget_name'][] = data_controller_get_operator_factory_instance()->initiateHandler(NotEmptyOperatorHandler::$OPERATOR__NAME);
     return $adjustedParameters;
   ",
   "template":"individual_filter"

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/nycha_budget/transactions_page_widgets/1034.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/nycha_budget/transactions_page_widgets/1034.json
@@ -51,7 +51,8 @@
     "display_funding_source_descr",
     "responsibility_center_description",
     "program_phase_description",
-    "gl_project_description"
+    "gl_project_description",
+    "budget_id"
   ],
   "caption": "",
   "derivedColumns": {
@@ -86,10 +87,10 @@
       "expression": "_get_tooltip_markup($row['expenditure_type_description'],36)"
     },
     "budget_name_formatted":{
-      "expression": "($row['budget_name'] == null) ? 'N/A' : _get_tooltip_markup($row['budget_name'],36)"
+      "expression": "_get_tooltip_markup(NychaBudgetUtil::getBudgetName($row['budget_id']),36)"
     },
     "budget_type_formatted":{
-      "expression": "($row['budget_type'] == null) ? 'N/A' :_get_tooltip_markup($row['budget_type'],36)"
+      "expression": "_get_tooltip_markup(NychaBudgetUtil::getBudgetType($row['budget_id']),36)"
     },
     "resp_center_formatted":{
       "expression": "_get_tooltip_markup($row['responsibility_center_description'],36)"


### PR DESCRIPTION
1) Disable null value display in facets and display only 'n/a' as 'n/a' in facets.
2) Display 'n/a' as 'n/a' and null as null for budget_type and budget_name in Nycha budget transactions
3) Remove null values from drop downs for budget_type and budget_name fields in datafeeds and advance search forms.