### PR TITLE
Feature nycchkbk 10302 - Nycha revenue 'n/a' and null value display update for budget_type and budget_name columns.

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_project/customclasses/revenue/NychaRevenueUtil.php
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/customclasses/revenue/NychaRevenueUtil.php
@@ -85,5 +85,23 @@ class NychaRevenueUtil{
     return $title;
   }
 
+  // NYCCHKBK - 10302
+  // Requirement for Transactions Page results - budget_type and budget_name to display null as null and 'n/a' as 'n/a'
+  static public function getRevenueBudgetName($revenueId)
+  {
+    $where = "WHERE revenue_id = '" . $revenueId . "' AND budget_name IS NOT NULL";
+    $query = "SELECT budget_name FROM revenue {$where} ";
+    $data = _checkbook_project_execute_sql_by_data_source($query, 'checkbook_nycha');
+    $result = isset($data[0]['budget_name'])? $data[0]['budget_name'] : null;
+    return $result;
+  }
+  static public function getRevenueBudgetType($revenueId)
+  {
+    $where = "WHERE revenue_id = '" . $revenueId . "' AND budget_type IS NOT NULL";
+    $query = "SELECT budget_type FROM revenue {$where} ";
+    $data = _checkbook_project_execute_sql_by_data_source($query, 'checkbook_nycha');
+    $result = isset($data[0]['budget_type'])? $data[0]['budget_type'] : null;
+    return $result;
+  }
 
 }

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/narrow_down_filters/nycha_revenue/1059.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/narrow_down_filters/nycha_revenue/1059.json
@@ -19,6 +19,7 @@
   if(function_exists('_checkbook_project_applyParameterFilters')){
   $adjustedParameters = _checkbook_project_applyParameterFilters($node,$parameters);
 }
+$adjustedParameters['budget_type.budget_type'][] = data_controller_get_operator_factory_instance()->initiateHandler(NotEmptyOperatorHandler::$OPERATOR__NAME);
 return $adjustedParameters;
 ",
 "template":"individual_filter"

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/narrow_down_filters/nycha_revenue/1060.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/narrow_down_filters/nycha_revenue/1060.json
@@ -19,6 +19,7 @@
   if(function_exists('_checkbook_project_applyParameterFilters')){
   $adjustedParameters = _checkbook_project_applyParameterFilters($node,$parameters);
 }
+$adjustedParameters['budget_name.budget_name'][] = data_controller_get_operator_factory_instance()->initiateHandler(NotEmptyOperatorHandler::$OPERATOR__NAME);
 return $adjustedParameters;
 ",
 "template":"individual_filter"

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/nycha_revenue/transactions_page_widgets/1051.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/nycha_revenue/transactions_page_widgets/1051.json
@@ -57,7 +57,8 @@
     "gl_project_description",
     "closing_classification_name",
     "revenue_category",
-    "revenue_class"
+    "revenue_class",
+    "revenue_id"
   ],
   "caption": "",
   "derivedColumns": {
@@ -65,7 +66,7 @@
       "expression": "_get_tooltip_markup($row['expenditure_type_description'], 28)"
     },
     "budget_type_formatted": {
-      "expression": "($row['budget_type'] == null) ? 'N/A' : _get_tooltip_markup($row['budget_type'], 36)"
+      "expression": "_get_tooltip_markup(NychaRevenueUtil::getRevenueBudgetName($row['revenue_id']),36)"
     },
     "formatted_adopted_amount": {
       "expression": "custom_number_formatter_basic_format($row['adopted_amount'])"
@@ -83,7 +84,7 @@
       "expression": "_get_tooltip_markup($row['expenditure_type_description'],36)"
     },
     "budget_name_formatted":{
-      "expression": "($row['budget_name'] == null) ? 'N/A' :_get_tooltip_markup($row['budget_name'],36)"
+      "expression": "_get_tooltip_markup(NychaRevenueUtil::getRevenueBudgetType($row['revenue_id']),36)"
     },
     "resp_center_formatted":{
       "expression": "_get_tooltip_markup($row['responsibility_center_description'],36)"


### PR DESCRIPTION
1. Disable null value display in facets and display only 'n/a' as 'n/a' in facets.
2. Display 'n/a' as 'n/a' and null as null for budget_type and budget_name in Nycha budget transactions