### PR TITLE
NYCCHKBK-10310 : Advance Search Form Revenue - Revenue Source and Class not updated

### DIFF
--- a/source/webapp/sites/all/themes/checkbook3/js/advanced-search.js
+++ b/source/webapp/sites/all/themes/checkbook3/js/advanced-search.js
@@ -1341,10 +1341,8 @@
           }
 
           //Clear autocomplete fields
-          div.ele('payee_name').val("");
-          div.ele('contract_id').val("");
-          div.ele('document_id').val("");
-          div.ele('capital_project').val("");
+          div.ele('revenue_source').val("");
+          div.ele('revenue_class').val("");
       }
 
         //On change of "Catastrophic event"


### PR DESCRIPTION
Refresh 'Revenue class' and 'Revenue source' when 'covid-19' is selected in Catastrophic events drop-down. Remove handling for auto-complete fields that don't exist in the form.