### PR TITLE
NYCCHKBK-10321: Datafeeds - Spending - Date filter list all years FY2011 to FY2021 for COVID19 dropdown 

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_datafeeds/checkbook_datafeeds.module
+++ b/source/webapp/sites/all/modules/custom/checkbook_datafeeds/checkbook_datafeeds.module
@@ -1733,13 +1733,6 @@ function checkbook_datafeeds_end_of_confirmation_form($form, &$form_state, $crit
     $form['count']['no_records'] = array(
       '#markup' => 'There are no records for the search criteria.',
     );
-    $form['prev'] = array(
-      '#type' => 'submit',
-      '#value' => t('Previous'),
-      '#name' => 'prev',
-      '#submit' => array('checkbook_datafeeds_' . $domain . '_confirmation_previous_submit'),
-      '#limit_validation_errors' => array(),
-    );
     $form['start_over'] = array(
       '#type' => 'submit',
       '#value' => t('Cancel'),

--- a/source/webapp/sites/all/modules/custom/checkbook_datafeeds/checkbook_datafeeds.module
+++ b/source/webapp/sites/all/modules/custom/checkbook_datafeeds/checkbook_datafeeds.module
@@ -1733,6 +1733,13 @@ function checkbook_datafeeds_end_of_confirmation_form($form, &$form_state, $crit
     $form['count']['no_records'] = array(
       '#markup' => 'There are no records for the search criteria.',
     );
+    $form['prev'] = array(
+      '#type' => 'submit',
+      '#value' => t('Previous'),
+      '#name' => 'prev',
+      '#submit' => array('checkbook_datafeeds_' . $domain . '_confirmation_previous_submit'),
+      '#limit_validation_errors' => array(),
+    );
     $form['start_over'] = array(
       '#type' => 'submit',
       '#value' => t('Cancel'),

--- a/source/webapp/sites/all/modules/custom/checkbook_datafeeds/js/spending.js
+++ b/source/webapp/sites/all/modules/custom/checkbook_datafeeds/js/spending.js
@@ -733,9 +733,6 @@
     })
   }
 
-  //When 'previous' button is clicked from datafeeds results page, the state of the drupal form is restored,
-  //but the 'disabled or limited options' of dropdown filters isn't restored
-  //So restore the state of these filters by explicity invoking events 
   $(document).ready(function () {
     onSpendingCategoryChange();
     onCatastrophicEventChange();

--- a/source/webapp/sites/all/modules/custom/checkbook_datafeeds/js/spending.js
+++ b/source/webapp/sites/all/modules/custom/checkbook_datafeeds/js/spending.js
@@ -130,7 +130,6 @@
         fiscal_year.options[i].style.display = '';
       }
     }
-    fiscal_year.value = "0"; 
 }
 
   //On Year filter dropdown change
@@ -142,8 +141,13 @@
     let fiscal_year = document.getElementById("edit-year").value.toLowerCase();
     let catastrophic_event = document.getElementById("edit-catastrophic-event");
     let enabled_count = catastrophic_event.length;
+    let spending_cat = ($('select[name="expense_type"]').val()) ? $('select[name="expense_type"]').val() : 0;
 
-    if(!(fiscal_year === "0" || fiscal_year === "fy2021" || fiscal_year === "fy2020")){
+    if (spending_cat === "Payroll [p]" || spending_cat === "Others [o]"){
+      disable_input($('select[name="catastrophic_event"]'));
+      return;
+    }
+    else if(!(fiscal_year === "0" || fiscal_year === "fy2021" || fiscal_year === "fy2020")){
       for (let i = 0; i < catastrophic_event.length; i++) {
         let event = catastrophic_event.options[i].text.toLowerCase();
         catastrophic_event.options[i].style.display = (event === 'covid-19')? "none":"";
@@ -728,5 +732,11 @@
       }
     })
   }
+
+  $(document).ready(function () {
+    onSpendingCategoryChange();
+    onCatastrophicEventChange();
+    onYearFilterChange();
+  });
 
 }(jQuery));

--- a/source/webapp/sites/all/modules/custom/checkbook_datafeeds/js/spending.js
+++ b/source/webapp/sites/all/modules/custom/checkbook_datafeeds/js/spending.js
@@ -733,6 +733,9 @@
     })
   }
 
+  //When 'previous' button is clicked from datafeeds results page, the state of the drupal form is restored,
+  //but the 'disabled or limited options' of dropdown filters isn't restored
+  //So restore the state of these filters by explicity invoking events 
   $(document).ready(function () {
     onSpendingCategoryChange();
     onCatastrophicEventChange();


### PR DESCRIPTION
**Handled the following concerns:**
- When 'previous' button is clicked from data feeds results page, form fields data is restored correctly, but the form fields that were 'disabled’ or whose ‘options were limited' because of other dropdown filters aren't restored correctly.
- When ‘year filter’ changes, if spending category is ‘payroll’ or ‘others’, keep catastrophic event filter disabled, no matter which year is selected.

