### PR TITLE
NYCCHKBK-10332: Datafeeds - Spending - No Results found for download data [COVID]

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_api/handler/XMLDataHandler.php
+++ b/source/webapp/sites/all/modules/custom/checkbook_api/handler/XMLDataHandler.php
@@ -194,7 +194,7 @@ class XMLDataHandler extends AbstractDataHandler
 
           //Get only column
           if (strpos($sql_part,".") !== false) {
-            $select_column_parts = explode('.', trim($sql_part));
+            $select_column_parts = explode('.', trim($sql_part), 2);
             $alias = $select_column_parts[0] . '.';
             $column = $select_column_parts[1];
           }else{


### PR DESCRIPTION
Handle 'CASE' statements in 'SELECT' query for XML for COVID branch