### PR TITLE
[COVID] NYCCHKBK-10382- Data-Feeds Spending, Revenue and Contracts Catastrophic Event field issue

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_datafeeds/includes/contracts/checkbook_datafeeds_contracts.inc
+++ b/source/webapp/sites/all/modules/custom/checkbook_datafeeds/includes/contracts/checkbook_datafeeds_contracts.inc
@@ -1400,7 +1400,7 @@ function checkbook_datafeeds_contracts_confirmation($form, &$form_state)
         $formatted_search_criteria['Category'] = $values['category'];
       }
       if ($values['category'] != 'revenue') {
-        if ($values['catastrophic_event'] !== '0' && ($values['year'] == '0' ||  (substr($values['year'],-4) >= 2020 ))) {
+        if ($values['catastrophic_event'] && ($values['year'] == '0' ||  (substr($values['year'],-4) >= 2020 ))) {
           $form['filter']['catastrophic_event'] = array('#markup' => '<div><strong>Catastrophic Event:</strong> ' . $values['catastrophic_event'] . '</div>');
           $user_criteria['Catastrophic Event'] = $values['catastrophic_event'];
           $formatted_search_criteria['Catastrophic Event'] = $values['catastrophic_event'];
@@ -1806,7 +1806,7 @@ function checkbook_datafeeds_process_contracts_values($form, &$form_state, $data
       }
 
       if ($values['category'] != 'revenue') {
-        if ($values['catastrophic_event'] !== '0' && ((substr($values['year'], -4) >= 2020) || $values['year'] == '0')) {
+        if ($values['catastrophic_event'] && ((substr($values['year'], -4) >= 2020) || $values['year'] == '0')) {
           preg_match($pattern, $values['catastrophic_event'], $ematches);
           $criteria['value']['catastrophic_event'] = trim($ematches[1], '[ ]');;
         }

--- a/source/webapp/sites/all/modules/custom/checkbook_datafeeds/includes/revenue/RevenueFeedCitywide.class.inc
+++ b/source/webapp/sites/all/modules/custom/checkbook_datafeeds/includes/revenue/RevenueFeedCitywide.class.inc
@@ -62,7 +62,7 @@ class RevenueFeedCitywide extends RevenueFeed{
     }
 
     //Catastrophic event filter
-    if ($this->values['catastrophic_event'] !== '0' && $this->values['budget_fiscal_year'] >= 2020 ) {
+    if ($this->values['catastrophic_event'] && $this->values['budget_fiscal_year'] >= 2020 ) {
       $catastrophic_events = _get_event_name_and_id();
       $catastrophic_event = $catastrophic_events[$this->values['catastrophic_event']]. "[" .$this->values['catastrophic_event']. "]";
       $this->form['filter']['catastrophic_event'] = array('#markup' => '<div><strong>Catastrophic Event:</strong> ' . $catastrophic_event . '</div>');
@@ -212,7 +212,7 @@ class RevenueFeedCitywide extends RevenueFeed{
        $this->criteria['value']['revenue_source'] = trim($rsmatches[1], '[ ]');;
     }
 
-    if ($this->values['catastrophic_event'] !== '0' && $this->values['budget_fiscal_year'] >= 2020 ) {
+    if ($this->values['catastrophic_event'] && $this->values['budget_fiscal_year'] >= 2020 ) {
       $this->criteria['value']['catastrophic_event'] = $this->values['catastrophic_event'];
     }
 

--- a/source/webapp/sites/all/modules/custom/checkbook_datafeeds/includes/spending/SpendingFeedCitywide.class.inc
+++ b/source/webapp/sites/all/modules/custom/checkbook_datafeeds/includes/spending/SpendingFeedCitywide.class.inc
@@ -72,7 +72,7 @@ class SpendingFeedCitywide extends SpendingFeed
 
     //Catastrophic event filter
     if ($this->values['expense_type'] != 'Payroll [p]') {
-      if ($this->values['catastrophic_event'] !== '0' && ($this->values['year'] == '0' || substr($this->values['year'], -4) >= 2020)) {
+      if ($this->values['catastrophic_event'] && ($this->values['year'] == '0' || substr($this->values['year'], -4) >= 2020)) {
         $catastrophic_events = _get_event_name_and_id();
         $catastrophic_event = $catastrophic_events[$this->values['catastrophic_event']] . "[" . $this->values['catastrophic_event'] . "]";
         $this->form['filter']['catastrophic_event'] = array('#markup' => '<div><strong>Catastrophic Event:</strong> ' . $catastrophic_event . '</div>');
@@ -181,7 +181,7 @@ class SpendingFeedCitywide extends SpendingFeed
     }
 
     if ($this->values['expense_type'] != 'Payroll [p]') {
-      if ($this->values['catastrophic_event'] !== '0' && ($this->values['year'] == '0' || substr($this->values['year'], -4) >= 2020))
+      if ($this->values['catastrophic_event'] && ($this->values['year'] == '0' || substr($this->values['year'], -4) >= 2020))
       {
         $this->criteria['value']['catastrophic_event'] = $this->values['catastrophic_event'];
       }


### PR DESCRIPTION
Handled scenarios where catastrophic event filter:
1. Gets disabled due to some selection. For example, in spending data feeds, Spending Category: Others [o] will disable catastrophic event filter
2. Has default option 'Select Event' selected