### PR TITLE
[COVID] NYCCHKBK-10291: Advanced search form Revenue - autocompletes not working

### DIFF
--- a/source/webapp/sites/all/themes/checkbook3/js/advanced-search.js
+++ b/source/webapp/sites/all/themes/checkbook3/js/advanced-search.js
@@ -1317,7 +1317,8 @@
           }
         }
 
-        onRevenueDataSourceChange("checkbook");
+        let dataSource = $('input:radio[name=revenue_advanced_search_domain_filter]:checked', context).val() ? $('input:radio[name=revenue_advanced_search_domain_filter]:checked', context).val() : "checkbook";
+        onRevenueDataSourceChange(dataSource);
 
         function onRevenueBudgetFiscalYearChange(div) {
           //Setting data source value

--- a/source/webapp/sites/all/themes/checkbook3/js/advanced-search.js
+++ b/source/webapp/sites/all/themes/checkbook3/js/advanced-search.js
@@ -1317,6 +1317,8 @@
           }
         }
 
+        onRevenueDataSourceChange("checkbook");
+
         function onRevenueBudgetFiscalYearChange(div) {
           //Setting data source value
           let data_source = $('input[type=radio][name=revenue_advanced_search_domain_filter]:checked').val();


### PR DESCRIPTION
Since data source / domain options (nycha, citywide) are hidden, added an explicit call to data source change function which eventually initializes autocomplete and other important aspects of the form.