### PR TITLE
Possible fix for Selenium testing issue

### DIFF
--- a/source/tests/functional/NYCAutomationTest/pom.xml
+++ b/source/tests/functional/NYCAutomationTest/pom.xml
@@ -65,6 +65,12 @@
             <artifactId>selenium-server</artifactId>
             <version>3.3.1</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-api -->
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-api</artifactId>
+            <version>3.3.1</version>
+        </dependency>
         <dependency>
             <groupId>com.github.detro.ghostdriver</groupId>
             <artifactId>phantomjsdriver</artifactId>


### PR DESCRIPTION
Jenkins build failed with error:
cannot access org.openqa.selenium.WrapsElement
  class file for org.openqa.selenium.WrapsElement not found

Found a similar error & solution here: https://stackoverflow.com/questions/52992915/selenium-selenide-class-file-for-org-openqa-selenium-wrapsdriver-not-found-for

Updating the pom.xml to add selenium-api repo for dependency