### PR TITLE
Feature nycchkbk 9894 - API Ref file generation module refactor to generate csv files only.

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_api_ref/checkbook_api_ref.info
+++ b/source/webapp/sites/all/modules/custom/checkbook_api_ref/checkbook_api_ref.info
@@ -1,0 +1,27 @@
+
+; This file is part of the Checkbook NYC financial transparency software.
+;
+; Copyright (C) 2012, 2013 New York City
+;
+; This program is free software: you can redistribute it and/or modify
+; it under the terms of the GNU Affero General Public License as
+; published by the Free Software Foundation, either version 3 of the
+; License, or (at your option) any later version.
+;
+; This program is distributed in the hope that it will be useful,
+; but WITHOUT ANY WARRANTY; without even the implied warranty of
+; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+; GNU Affero General Public License for more details.
+;
+; You should have received a copy of the GNU Affero General Public License
+; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;  Copyright 2009-2011 United States Government.
+;
+name = "Checkbook Api Ref Files"
+description = "API CSV Ref files generation every week"
+php = 7.2
+package = NYC Checkbook
+core = 7.x
+dependencies[] = checkbook_mail_system
+
+files[] = includes/CheckbookApiRef.class.php

--- a/source/webapp/sites/all/modules/custom/checkbook_api_ref/checkbook_api_ref.install
+++ b/source/webapp/sites/all/modules/custom/checkbook_api_ref/checkbook_api_ref.install
@@ -1,0 +1,19 @@
+<?php
+
+function checkbook_api_ref_enable() {
+  if (class_exists('CheckbookMailSystem')){
+    $current = variable_get('mail_system', array('default-system' => 'DefaultMailSystem'));
+    if (!isset($current['checkbook_api_ref'])){
+      $addition = array('checkbook_api_ref' => 'CheckbookMailSystem');
+      variable_set('mail_system', array_merge($current, $addition));
+    }
+  }
+}
+
+function checkbook_api_ref_disable() {
+  $mail_system = variable_get('mail_system', array('default-system' => 'DefaultMailSystem'));
+  if (isset($mail_system['checkbook_api_ref'])){
+    unset($mail_system['checkbook_api_ref']);
+    variable_set('mail_system', $mail_system);
+  }
+}

--- a/source/webapp/sites/all/modules/custom/checkbook_api_ref/checkbook_api_ref.module
+++ b/source/webapp/sites/all/modules/custom/checkbook_api_ref/checkbook_api_ref.module
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Implements hook_cron().
+ */
+function checkbook_api_ref_cron() {
+  $CES = new CheckbookApiRef();
+  return $CES->run_cron();
+}
+
+/**
+ * Implements hook_mail().
+ * @param $key
+ * @param $message
+ * @param $params
+ */
+function checkbook_api_ref_mail($key, &$message, $params){
+  $CES = new CheckbookApiRef();
+  $CES->gatherData($message);
+
+  $message['body'] = array_merge($message['body'], $params);
+}
+
+/**
+ * Implements hook_mail_alter().
+ *
+ * Adds priority headers to messages passing condition.
+ * @param $message
+ * @throws Exception
+ */
+function checkbook_api_ref_mail_alter(&$message)
+{
+  // Apply this hook only for `checkbook_etl_status` module
+  if ('checkbook_api_ref' !== $message['module']) {
+    return;
+  }
+  if (stripos($message['subject'], 'Fail') || stripos($message['subject'], 'not Found')) {
+    $message['headers']['X-Priority'] = '1 (Highest)';
+    $message['headers']['X-MSMail-Priority'] = 'High';
+    $message['headers']['Importance'] = 'High';
+  }
+  $message['headers']['Content-Type'] = 'text/html; charset=UTF-8; format=flowed; delsp=yes';
+  $message['body'] = theme('api_ref_mail', $message['body']);
+  if (defined('CHECKBOOK_DEV')) {
+    echo($message['body']);
+    $message['send'] = false;
+  }
+}
+
+/**
+ * Implements hook_theme()
+ * @param $existing
+ * @param $type
+ * @param $theme
+ * @param $path
+ * @return array
+ */
+function checkbook_api_ref_theme($existing, $type, $theme, $path)
+{
+  if ($type == 'module') {
+    return array(
+      'api_ref_mail' => array(
+        'variables' => array(
+          'file_generation_status' => NULL
+        ),
+        'template' => 'api-ref.email',
+        'path' => drupal_get_path('module', 'checkbook_api_ref') . '/theme',
+      ),
+    );
+  }
+}

--- a/source/webapp/sites/all/modules/custom/checkbook_api_ref/config/ref_file_sql.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_api_ref/config/ref_file_sql.json
@@ -1,0 +1,8 @@
+{
+  "agency_code_list": {
+    "sql": "SELECT DISTINCT t1.agency_code, t1.agency_name FROM ref_agency t1 where t1.is_display = 'Y' AND EXISTS ( select 1 from all_disbursement_transactions t2 where t2.agency_id = t1.agency_id ) ORDER BY t1.agency_name",
+    "force_quote": [
+      "agency_code"
+    ]
+  }
+}

--- a/source/webapp/sites/all/modules/custom/checkbook_api_ref/config/ref_file_sql.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_api_ref/config/ref_file_sql.json
@@ -4,5 +4,295 @@
     "force_quote": [
       "agency_code"
     ]
+  },
+  "vendor_code_list": {
+    "sql": "SELECT DISTINCT t1.vendor_customer_code, t1.legal_name FROM vendor t1 WHERE EXISTS ( select 1 from all_disbursement_transactions t2 where t2.vendor_id = t1.vendor_id ) ORDER BY t1.vendor_customer_code",
+    "force_quote": [
+      "vendor_customer_code"
+    ]
+  },
+  "department_code_list": {
+    "sql": "SELECT DISTINCT d.department_code, d.department_name, a.agency_code, a.agency_name FROM ref_department d LEFT OUTER JOIN ref_agency a  ON d.agency_id = a.agency_id WHERE EXISTS ( select 1 from budget b where d.department_id = b.department_id ) ORDER BY d.department_name",
+    "force_quote": [
+      "department_code",
+      "agency_code"
+    ]
+  },
+  "spending_mwbe_code_list": {
+    "sql": "select minority_type_id,minority_type_name from (select minority_type_id::text,CASE WHEN minority_type_id = 2 THEN 'Black American' WHEN minority_type_id = 3 THEN 'Hispanic American' WHEN minority_type_id = 4 THEN 'Asian American' WHEN minority_type_id = 5 THEN 'Asian American'  WHEN minority_type_id = 6 THEN 'Native' WHEN minority_type_id = 7 THEN 'Non-M/WBE' WHEN minority_type_id = 9 THEN 'Women' WHEN minority_type_id = 11 THEN 'Individuals & Others' WHEN minority_type_id = 99 THEN 'Emerging'  END AS minority_type_name FROM ref_minority_type where minority_type_id in (2,3,4,5,6,7,9,11,99) union SELECT  '2~3~4~5~6~9~99' as minority_type_id , 'Total M/WBE' as minority_type_name )A order by idx(array['2','3','4','5','6','7','9','11','99','2~3~4~5-6~9-99'],minority_type_id)"
+  },
+  "industry_code_list": {
+    "sql": "SELECT DISTINCT t1.industry_type_id, t1.industry_type_name FROM ref_industry_type t1 WHERE EXISTS ( select 1 from all_agreement_transactions t2 where t2.industry_type_id = t1.industry_type_id ) ORDER BY t1.industry_type_id"
+  },
+  "budget_code_list": {
+    "sql": "SELECT DISTINCT bc.budget_code \"Budget Code\", bc.attribute_name \"Budget Code Name\" FROM ref_budget_code bc WHERE EXISTS ( select 1 from budget b where bc.budget_code_id = b.budget_code_id ) ORDER BY bc.attribute_name",
+    "force_quote": [
+      "Budget Code"
+    ]
+  },
+  "budget_expense_category_code_list": {
+    "sql": "SELECT DISTINCT oc.object_class_code, oc.object_class_name FROM ref_object_class oc WHERE EXISTS ( select 1 from budget b where  oc.object_class_id = b.object_class_id ) ORDER BY oc.object_class_name",
+    "force_quote": [
+      "object_class_code"
+    ]
+  },
+  "revenue_class_code_list": {
+    "sql": "SELECT DISTINCT t1.revenue_class_code, t1.revenue_class_name FROM ref_revenue_class t1 WHERE EXISTS ( select 1 from revenue_details t2 where t2.revenue_class_id  = t1.revenue_class_id ) ORDER BY t1.revenue_class_name",
+    "force_quote": [
+      "revenue_class_code"
+    ]
+  },
+  "fund_class_code_list": {
+    "sql": "SELECT DISTINCT t1.fund_class_code, t1.fund_class_name FROM ref_fund_class t1 WHERE t1.fund_class_name = 'General Fund' AND EXISTS ( select 1 from revenue_details t2 where t2.fund_class_id = t1.fund_class_id ) ORDER BY t1.fund_class_name",
+    "force_quote": [
+      "fund_class_code"
+    ]
+  },
+  "funding_source_code_list": {
+    "sql": "SELECT DISTINCT t1.funding_class_code, t1.funding_class_name FROM ref_funding_class t1 WHERE EXISTS ( select 1 from revenue_details t2 where t2.funding_class_id = t1.funding_class_id ) ORDER BY t1.funding_class_name",
+    "force_quote": [
+      "funding_class_code"
+    ]
+  },
+  "revenue_category_code_list": {
+    "sql": "SELECT DISTINCT t1.revenue_category_code, t1.revenue_category_name FROM ref_revenue_category t1 WHERE EXISTS ( select 1 from revenue_details t2 where t2.revenue_category_id  = t1.revenue_category_id ) ORDER BY t1.revenue_category_name",
+    "force_quote": [
+      "revenue_category_code"
+    ]
+  },
+  "revenue_source_code_list": {
+    "sql": "SELECT DISTINCT t1.revenue_source_code, t1.revenue_source_name FROM ref_revenue_source t1 WHERE EXISTS ( select 1 from revenue_details t2 where t2.revenue_source_id = t1.revenue_source_id ) ORDER BY t1.revenue_source_name",
+    "force_quote": [
+      "revenue_source_code"
+    ]
+  },
+  "payee_code_list": {
+    "sql": "SELECT DISTINCT t1.vendor_customer_code, t1.legal_name FROM vendor t1 WHERE EXISTS ( select 1 from all_disbursement_transactions t2 where t2.vendor_id = t1.vendor_id ) ORDER BY t1.legal_name",
+    "force_quote": [
+      "vendor_customer_code"
+    ]
+  },
+  "expense_code_list": {
+    "disabled": true,
+    "sql": "SELECT DISTINCT document_id FROM history_master_agreement ORDER BY document_id",
+    "force_quote": [
+      "document_id"
+    ]
+  },
+  "spending_expense_category_code_list": {
+    "sql": "SELECT DISTINCT t1.expenditure_object_code, t1.expenditure_object_name FROM ref_expenditure_object t1 WHERE EXISTS ( select 1 from all_disbursement_transactions t2 where t2.expenditure_object_id = t1.expenditure_object_id ) ORDER BY t1.expenditure_object_name",
+    "force_quote": [
+      "expenditure_object_code"
+    ]
+  },
+  "capital_project_code_list": {
+    "sql": "SELECT DISTINCT reporting_code \"Capital Project Code\" FROM disbursement_line_item_details where coalesce(reporting_code,'') <> '' ORDER BY reporting_code",
+    "force_quote": [
+      "Capital Project Code"
+    ]
+  },
+  "document_id_code_list": {
+    "disabled": true,
+    "sql": "SELECT DISTINCT \"disbursement_number\" FROM disbursement_line_item_details ORDER BY disbursement_number",
+    "force_quote": [
+      "disbursement_number"
+    ]
+  },
+  "spending_category_code_list": {
+    "sql": "SELECT DISTINCT spending_category_name, spending_category_code FROM ref_spending_category ORDER BY spending_category_name",
+    "force_quote": [
+      "spending_category_name"
+    ]
+  },
+  "contract_type_code_list": {
+    "sql": "SELECT DISTINCT agreement_type_code, agreement_type_name FROM ref_agreement_type ORDER BY agreement_type_code",
+    "force_quote": [
+      "agreement_type_code"
+    ]
+  },
+  "award_method_code_list": {
+    "sql": "SELECT DISTINCT t1.award_method_code, t1.award_method_name FROM ref_award_method t1 WHERE EXISTS ( select 1 from all_agreement_transactions t2 where t2.award_method_id = t1.award_method_id ) ORDER BY t1.award_method_code",
+    "force_quote": [
+      "award_method_code"
+    ]
+  },
+  "nycha_vendor_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "SELECT DISTINCT t1.vendor_customer_code, t1.vendor_name FROM vendor t1 WHERE EXISTS ( select 1 from all_disbursement_transactions t2 where t2.vendor_id = t1.vendor_id ) ORDER BY t1.vendor_customer_code",
+    "force_quote": [
+      "vendor_customer_code"
+    ]
+  },
+  "nycha_contract_type_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "SELECT DISTINCT contract_type_code, contract_type_name FROM ref_contract_type ORDER BY contract_type_code",
+    "force_quote": [
+      "contract_type_name"
+    ]
+  },
+  "nycha_award_method_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "SELECT DISTINCT t1.award_method_code, t1.award_method_name FROM ref_award_method t1 WHERE EXISTS ( select 1 from all_agreement_transactions t2 where t2.award_method_id = t1.award_method_id ) ORDER BY t1.award_method_code",
+    "force_quote": [
+      "award_method_code"
+    ]
+  },
+  "nycha_industry_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "SELECT DISTINCT t1.industry_type_code, t1.display_industry_type_name FROM ref_industry_type t1 WHERE EXISTS ( select 1 from all_agreement_transactions t2 where t2.industry_type_code = t1.industry_type_code ) ORDER BY t1.industry_type_code",
+    "force_quote": [
+      "display_industry_type_name"
+    ]
+  },
+  "nycha_purchase_order_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "SELECT DISTINCT agreement_type_code, agreement_type_name FROM ref_agreement_type ORDER BY agreement_type_code",
+    "force_quote": [
+      "agreement_type_name"
+    ]
+  },
+  "nycha_responsibility_center_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "SELECT DISTINCT responsibility_center_code, responsibility_center_description FROM ref_responsibility_center WHERE responsibility_center_description IS NOT NULL AND responsibility_center_id NOT IN (1032,2066) ORDER BY responsibility_center_code",
+    "force_quote": [
+      "responsibility_center_description"
+    ]
+  },
+  "nycha_spending_category_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "SELECT DISTINCT spending_category_code,spending_category_id, display_spending_category_name AS spending_category_name FROM ref_spending_category order by 1",
+    "force_quote": [
+      "spending_category_name"
+    ]
+  },
+  "nycha_department_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "SELECT DISTINCT l.department_code, h.department_name from ref_department_history h join ref_department l on l.department_id = h.department_id order by 1",
+    "force_quote": [
+      "department_code"
+    ]
+  },
+  "nycha_funding_source_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "SELECT DISTINCT l.funding_source_code, h.display_funding_source_descr AS funding_source_description from ref_funding_source_history h join ref_funding_source l on l.funding_source_id = h.funding_source_id order by 1",
+    "force_quote": [
+      "funding_source_code"
+    ]
+  },
+  "nycha_expense_category_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "SELECT DISTINCT l.expenditure_type_code,h.expenditure_type_description from ref_expenditure_type_history h join ref_expenditure_type l on l.expenditure_type_id = h.expenditure_type_id where h.expenditure_type_description IS NOT NULL order by 1",
+    "force_quote": [
+      "expenditure_type_code"
+    ]
+  },
+  "nycha_budget_expenditure_type_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "SELECT DISTINCT expenditure_type_code, expenditure_type_description FROM ref_expenditure_type where account_type ='Expense' AND expenditure_type_code IS NOT NULL AND expenditure_type_description IS NOT NULL AND expenditure_type_description NOT IN (' ','<Unknown>','xxxxxxx') AND NOT expenditure_type_description ~ '^'''",
+    "force_quote": [
+      "expenditure_type_code"
+    ]
+  },
+  "nycha_budget_funding_source_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "SELECT DISTINCT funding_source_code, display_funding_source_descr FROM public.ref_funding_source where funding_source_code IS NOT NULL and display_funding_source_descr IS NOT NULL AND display_funding_source_descr NOT IN (' ','<Unknown>','xxxxxxx') AND NOT display_funding_source_descr ~ '^'''",
+    "force_quote": [
+      "funding_source_code"
+    ]
+  },
+  "nycha_budget_project_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "SELECT DISTINCT gl_project_code, gl_project_description FROM public.ref_gl_project where gl_project_code IS NOT NULL and gl_project_description IS NOT NULL AND gl_project_description NOT IN (' ','<Unknown>','xxxxxxx') AND NOT gl_project_description ~ '^'''",
+    "force_quote": [
+      "gl_project_code"
+    ]
+  },
+  "nycha_budget_program_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "SELECT DISTINCT program_phase_code, program_phase_description FROM public.ref_program_phase where program_phase_code IS NOT NULL AND program_phase_description IS NOT NULL AND program_phase_description NOT IN (' ','<Unknown>','xxxxxxx') AND NOT program_phase_description ~ '^'''",
+    "force_quote": [
+      "program_phase_code"
+    ]
+  },
+  "nycha_budget_responsibility_center_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "SELECT DISTINCT responsibility_center_code, responsibility_center_description FROM public.ref_responsibility_center where responsibility_center_code IS NOT NULL AND responsibility_center_description IS NOT NULL AND responsibility_center_description NOT IN (' ','<Unknown>','xxxxxxx') AND NOT responsibility_center_description ~ '^'''",
+    "force_quote": [
+      "responsibility_center_code"
+    ]
+  },
+  "nycha_budget_type_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "SELECT DISTINCT budget_type from public.budget",
+    "force_quote": [
+      "budget_type"
+    ]
+  },
+  "nycha_budget_name_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "SELECT DISTINCT budget_name from public.budget",
+    "force_quote": [
+      "budget_name"
+    ]
+  },
+  "nycha_revenue_expenditure_type_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "SELECT DISTINCT expenditure_type_code, expenditure_type_description FROM ref_expenditure_type where account_type ='Revenue' AND expenditure_type_code IS NOT NULL AND expenditure_type_description IS NOT NULL AND expenditure_type_description NOT IN (' ','<Unknown>','xxxxxxx') AND NOT expenditure_type_description ~ '^'''",
+    "force_quote": [
+      "expenditure_type_code"
+    ]
+  },
+  "nycha_revenue_funding_source_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "SELECT DISTINCT funding_source_code, display_funding_source_descr FROM public.ref_funding_source where funding_source_code IS NOT NULL and display_funding_source_descr IS NOT NULL AND display_funding_source_descr NOT IN (' ','<Unknown>','xxxxxxx') AND NOT display_funding_source_descr ~ '^'''",
+    "force_quote": [
+      "funding_source_code"
+    ]
+  },
+  "nycha_revenue_project_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "SELECT DISTINCT gl_project_code, gl_project_description FROM public.ref_gl_project where gl_project_code IS NOT NULL and gl_project_description IS NOT NULL AND gl_project_description NOT IN (' ','<Unknown>','xxxxxxx') AND NOT gl_project_description ~ '^'''",
+    "force_quote": [
+      "gl_project_code"
+    ]
+  },
+  "nycha_revenue_program_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "SELECT DISTINCT program_phase_code, program_phase_description FROM public.ref_program_phase where program_phase_code IS NOT NULL AND program_phase_description IS NOT NULL AND program_phase_description NOT IN (' ','<Unknown>','xxxxxxx') AND NOT program_phase_description ~ '^'''",
+    "force_quote": [
+      "program_phase_code"
+    ]
+  },
+  "nycha_revenue_responsibility_center_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "SELECT DISTINCT responsibility_center_code, responsibility_center_description FROM public.ref_responsibility_center where responsibility_center_code IS NOT NULL AND responsibility_center_description IS NOT NULL AND responsibility_center_description NOT IN (' ','<Unknown>','xxxxxxx') AND NOT responsibility_center_description ~ '^'''",
+    "force_quote": [
+      "responsibility_center_code"
+    ]
+  },
+  "nycha_revenue_budget_type_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "SELECT DISTINCT budget_type from public.revenue",
+    "force_quote": [
+      "budget_type"
+    ]
+  },
+  "nycha_revenue_budget_name_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "SELECT DISTINCT budget_name from public.revenue",
+    "force_quote": [
+      "budget_name"
+    ]
+  },
+  "nycha_revenue_category_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "select distinct revenue_category from public.revenue",
+    "force_quote": [
+      "revenue_category"
+    ]
+  },
+  "nycha_revenue_class_code_list": {
+    "database": "checkbook_nycha",
+    "sql": "select distinct revenue_class from public.revenue"
   }
 }

--- a/source/webapp/sites/all/modules/custom/checkbook_api_ref/includes/CheckbookApiRef.class.php
+++ b/source/webapp/sites/all/modules/custom/checkbook_api_ref/includes/CheckbookApiRef.class.php
@@ -1,0 +1,195 @@
+<?php
+
+/**
+ * Class CheckbookApiRef
+ */
+class CheckbookApiRef
+{
+  /**
+   * @var string
+   */
+  public static $message_body = '';
+
+  /**
+   * Last ETL must successfully finish within last 12 hours
+   */
+  const SUCCESS_IF_RUN_LESS_THAN_X_SECONDS_AGO = 60 * 60 * 12;
+
+  const CRON_LAST_RUN_DRUPAL_VAR = 'checkbook_api_ref_status_last_run';
+
+  /**
+   * @param $format
+   * @return false|string
+   */
+  public function get_date($format)
+  {
+    return date($format, self::timeNow());
+  }
+
+  /**
+   * @return int
+   */
+  public function timeNow()
+  {
+    return time();
+  }
+
+
+
+  /**
+   * @param $message
+   * @return array
+   */
+  public function generateRefFiles()
+  {
+
+    global $conf;
+
+    ini_set('max_execution_time',60*60);
+
+    $dir = variable_get('file_public_path', 'sites/default/files') . '/' . $conf['check_book']['data_feeds']['output_file_dir'];
+    $dir = realpath($dir);
+    if (!file_prepare_directory($dir, FILE_CREATE_DIRECTORY)) {
+      $return['error'] = "Could not prepare directory $dir for generating reference data.";
+      return $return;
+    }
+
+    $dir .= '/' . $conf['check_book']['ref_data_dir'];
+    if (!file_prepare_directory($dir, FILE_CREATE_DIRECTORY)) {
+      $return['error'] = "Could not prepare directory $dir for generating reference data.";
+      return $return;
+    }
+
+    $ref_files_list = json_decode(file_get_contents(__DIR__.'/../config/ref_file_sql.json'));
+    foreach($ref_files_list as $filename => $ref_file) {
+      if ($ref_file->disabled) {
+        continue;
+      }
+
+      $file_info = [];
+      $file = $dir . '/' . $filename . '.csv';
+      $file_info['error'] = false;
+
+      $data_source = $ref_file->database??'checkbook';
+      $result =_checkbook_project_execute_sql_by_data_source ($ref_file->sql,$data_source);
+
+      //Get the column names.
+      $columnNames = array();
+      if(!empty($result)){
+        $firstRow = $result[0];
+        foreach($firstRow as $colName => $val){
+          $columnNames[] = $colName;
+        }
+      }
+      $file = fopen($file, 'w');
+      //write column names to the file.
+      fputcsv($file, $columnNames);
+
+      foreach ($result as $row) {
+        // Wrap code values with quotes so that leading zeros are displayed in csv
+        $row[$ref_file->force_quote[0]]= "=\"" .$row[$ref_file->force_quote[0]]. "\"";
+        fputcsv($file, $row);
+      }
+      fclose( $file);
+      unset($result);
+    }
+
+    $return['success'] = "Ref Files Generated";
+    return $return;
+
+  }
+
+
+  /**
+   * @param $message
+   * @return array
+   */
+  public function gatherData(&$message)
+  {
+    global $conf;
+
+    $result = self::generateRefFiles();
+    //var_dump ($result);
+
+    $msg = [];
+    $msg['body'] = "Test API REF FILE Generated";
+
+    self::$message_body =
+      [
+        'file_generation_status' => "Generated ref files"
+      ];
+
+    $date = self::get_date('m-d-Y');
+    $msg['subject'] = $conf['CHECKBOOK_ENV']."API REF FILES GENERATED: " . self::$successSubject . " ($date)";
+    $msg['body'] = self::$message_body;
+    $message = array_merge($message, $msg);
+
+    //Send Status to all recipients when ETL Statistics are not empty
+    $message['to'] = $conf['checkbook_dev_group_email'];
+    return $message;
+  }
+  /**
+   * @return bool
+   */
+  public function run_cron()
+  {
+    global $conf;
+
+    date_default_timezone_set('America/New_York');
+
+    //always run cron for developer
+    if (defined('CHECKBOOK_DEV')) {
+      return self::sendmail();
+    }
+    if (!isset($conf['checkbook_dev_group_email'])) {
+      //error_log("API REF CRON skips. Reason: \$conf['checkbook_dev_group_email'] not defined");
+      return false;
+    }
+
+    if (empty($conf['CHECKBOOK_ENV']) || !in_array($conf['CHECKBOOK_ENV'], ['DEV2'])) {
+      // we run this cron only on DEV2 and PHPUNIT
+      return false;
+    }
+
+    $this_month = self::get_date('M');
+    $current_hour = self::get_date('w');
+    LogHelper::log_info($this_month);
+    LogHelper::log_info($current_hour);
+
+    $this_month = self::get_date('Y-m');
+    $current_hour = (int)self::get_date('H');
+
+    if (variable_get(self::CRON_LAST_RUN_DRUPAL_VAR) == $this_month) {
+      //error_log("API CRON skips. Reason: already ran this month :: $this_month :: ".variable_get($variable_name));
+      return false;
+    }
+
+    //if ($current_hour < 9 || $current_hour > 10) {
+      //error_log("API CRON skips. Reason: will run between 9 AM and 11 AM EST :: current hour: $current_hour");
+      //return false;
+    //}
+    variable_set(self::CRON_LAST_RUN_DRUPAL_VAR, $this_month);
+    return self::sendmail();
+  }
+
+  /**
+   * @return bool
+   */
+  public function sendmail()
+  {
+    global $conf;
+
+    $from = $conf['email_from'];
+
+    if (isset($conf['checkbook_dev_group_email'])) {
+      $to = $conf['checkbook_dev_group_email'];
+      try{
+        drupal_mail('checkbook_api_ref', 'send-status', $to, null, ['dev_mode'=> false], $from);
+      } catch(Exception $ex2){
+        error_log($ex2->getMessage());
+      }
+    }
+    return true;
+  }
+
+}

--- a/source/webapp/sites/all/modules/custom/checkbook_api_ref/theme/api-ref.email.tpl.php
+++ b/source/webapp/sites/all/modules/custom/checkbook_api_ref/theme/api-ref.email.tpl.php
@@ -1,0 +1,21 @@
+<?php
+$prod_process_errors = FALSE;
+if(isset($prod_stats)) {
+  foreach ($prod_stats as $prod_stat) {
+    if ($prod_stat['Last Run Success?'] == 'Fail') {
+      if ($prod_stat['All Files Processed?'] == 'N' && $prod_stat['Shards Refreshed?'] == 'Y' && $prod_stat['Solr Refreshed?'] == 'Y') {
+        $prod_process_errors = TRUE;
+      }
+    }
+  }
+}
+$uat_process_errors = FALSE;
+if(isset($uat_stats)) {
+  foreach ($uat_stats as $uat_stat) {
+    if ($uat_stat['Last Run Success?'] == 'Fail') {
+      if ($uat_stat['All Files Processed?'] == 'N' && $uat_stat['Shards Refreshed?'] == 'Y' && $uat_stat['Solr Refreshed?'] == 'Y') {
+        $uat_process_errors = TRUE;
+      }
+    }
+  }
+}


### PR DESCRIPTION
1) The code has been refactored to generate only csv files . Issue with generating codes correctly with leading zeros has been fixed. 
2) The old module has not been deleted yet.
3) Need to enable the module in the drupal page once the code is pushed and also eventually disable the old module also.
4) Need to verify if the files are getting generated correctly in dev environment. Verification done only in local.