### PR TITLE
Defect NYCCHKBK-10424: Add spacing in SQL query to solve syntax error for special case in top navigation SQL query

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_project/customclasses/util/MappingUtil.php
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/customclasses/util/MappingUtil.php
@@ -391,7 +391,7 @@ class MappingUtil {
                     $where_filter = ' WHERE ' . implode(' AND ' , $where_filters);
                 }
 
-                $sql = 'SELECT a1.minority_type_id FROM ' . $table . ' a1' . $where_filter . 'GROUP BY a1.minority_type_id  ';
+                $sql = 'SELECT a1.minority_type_id FROM ' . $table . ' a1 ' . $where_filter . ' GROUP BY a1.minority_type_id  ';
                 $data = _checkbook_project_execute_sql($sql);
                 break;
             case "contracts":


### PR DESCRIPTION
- When $where_filter is empty, syntax error comes up. This pull request solves the same.