### PR TITLE
defect NYCCHKBK-10579 : NYCHA Spending Advanced Search Expense Category drop down issue

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_advanced_search/includes/spending_advanced_search.inc
+++ b/source/webapp/sites/all/modules/custom/checkbook_advanced_search/includes/spending_advanced_search.inc
@@ -183,7 +183,7 @@ function generateNYCHASpendingSearchUrl($form){
   $redirectUrl .= ($department != "Select Department" && !empty($department)) ?  _checkbook_advanced_search_generate_redirect_url($department, 'deptnm'): "";
   //Expense Category
   $expenseCategory = trim($form[$filterDimension][$filterDimension . '_expense_category']['#value']);
-  $redirectUrl .= ($expenseCategory != "Select Expense Category" && !empty($expenseCategory)) ?  _checkbook_advanced_search_generate_redirect_url($expenseCategory, 'expcategorycode'): "";
+  $redirectUrl .= ($expenseCategory != "Select Expense Category" && ($expenseCategory === "0" || !empty($expenseCategory))) ?  _checkbook_advanced_search_generate_redirect_url($expenseCategory, 'expcategorycode'): "";
   //Spending Category
   $spendingCategory = trim($form[$filterDimension][$filterDimension . '_expense_type']['#value']);
   $redirectUrl .= !empty($spendingCategory) ? _checkbook_advanced_search_generate_redirect_url($spendingCategory, 'category') : "";

--- a/source/webapp/sites/all/themes/checkbook3/js/advanced-search.js
+++ b/source/webapp/sites/all/themes/checkbook3/js/advanced-search.js
@@ -1600,7 +1600,8 @@
             dept = dept.toString().replace(/\//g, "__");
           }
           let exptype = (div.ele('spending_category').val()) ? (div.ele('spending_category').val()) : 0;
-          let expCat = (div.ele('exp_category').val()) ? (div.ele('exp_category').val()) : '';
+          let expCat = (div.ele('exp_category').val() && div.ele('exp_category').text() !== "Select Expense Category") 
+                        ? (div.ele('exp_category').val()) : '';
 
           $.ajax({
             url: '/advanced-search/autocomplete/spending/expcategory/' + year + '/' + agency + '/' + dept + '/' + exptype + '/' + data_source


### PR DESCRIPTION
Solves two issues:
1. Expense category drop down has “Payroll summary” which has code “0” which is the same as default “0”, resulting in drop down changing value to “Payroll summary” unexpectedly just after the nycha spending form loads.
2. Payroll summary having code “0” results in it being skipped from filters in advanced search spending transactions page.