### PR TITLE
Feature nycchkbk 9894: Modify API ref cron time line

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_api_ref/includes/CheckbookApiRef.class.php
+++ b/source/webapp/sites/all/modules/custom/checkbook_api_ref/includes/CheckbookApiRef.class.php
@@ -255,6 +255,10 @@ class CheckbookApiRef
       return false;
     }
 
+    if ($current_hour < 9 || $current_hour > 10) {
+      return false;
+    }
+
     variable_set(self::CRON_LAST_RUN_DRUPAL_VAR, $today);
     return self::sendmail();
   }


### PR DESCRIPTION
Modify API ref cron time line to allow it to run it only between 9:00 am to 10:59 am in order to keep it in the same time frame as other emails