### PR TITLE
Defect nycchkbk 10681 : Data feeds/Advanced Search Citywide Contracts Pending - Reset default fields

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_datafeeds/includes/contracts/checkbook_datafeeds_contracts.inc
+++ b/source/webapp/sites/all/modules/custom/checkbook_datafeeds/includes/contracts/checkbook_datafeeds_contracts.inc
@@ -1343,12 +1343,16 @@ function checkbook_datafeeds_contracts_confirmation($form, &$form_state)
         $user_criteria['Contract ID'] = $values['contractno'];
         $formatted_search_criteria[''] = null;
       }
-      if ($values['contract_includes_sub_vendors_id'] != '' && $values['contract_includes_sub_vendors_id'] != 0) {
+
+      if ($values['category'] != 'revenue' && $values['df_contract_status'] != 'pending') {
+        if ($values['contract_includes_sub_vendors_id'] != '' && $values['contract_includes_sub_vendors_id'] != 0) {
           $scntrc_status_name = MappingUtil::getscntrc_status_name($values['contract_includes_sub_vendors_id']);
           $form['filter']['contract_includes_sub_vendors_id'] = array('#markup' => '<div><strong>Contract Includes Sub Vendors:</strong> ' . $scntrc_status_name . '</div>');
           $user_criteria['Contract Includes Sub Vendors'] = $values['contract_includes_sub_vendors_id'];
           $formatted_search_criteria['Contract Includes Sub Vendors'] = $scntrc_status_name;
         }
+      }
+
       if ($values['pin']) {
         $form['filter']['pin'] = array(
           '#markup' => '<div><strong>PIN:</strong> ' . $values['pin'] . '</div>',
@@ -1410,14 +1414,17 @@ function checkbook_datafeeds_contracts_confirmation($form, &$form_state)
           $formatted_search_criteria['Catastrophic Event'] = $values['catastrophic_event'];
         }
       }
-      if ($values['sub_vendor_status_in_pip_id']) {
-        if ($values['sub_vendor_status_in_pip_id'] != 'Select Status') {
-          $aprv_sta_name = MappingUtil::getaprv_sta_name($values['sub_vendor_status_in_pip_id']);
-          $form['filter']['sub_vendor_status_in_pip_id'] = array('#markup' => '<div><strong>Sub Vendor Status in PIP&nbsp;:</strong> ' . $aprv_sta_name . '</div>');
-          $user_criteria['Sub Vendor Status in PIP'] = $values['sub_vendor_status_in_pip_id'];
-          $formatted_search_criteria['Sub Vendor Status in PIP'] = $aprv_sta_name;
+      if ($values['category'] != 'revenue' && $values['df_contract_status'] != 'pending') {
+        if ($values['sub_vendor_status_in_pip_id']) {
+          if ($values['sub_vendor_status_in_pip_id'] != 'Select Status') {
+            $aprv_sta_name = MappingUtil::getaprv_sta_name($values['sub_vendor_status_in_pip_id']);
+            $form['filter']['sub_vendor_status_in_pip_id'] = array('#markup' => '<div><strong>Sub Vendor Status in PIP&nbsp;:</strong> ' . $aprv_sta_name . '</div>');
+            $user_criteria['Sub Vendor Status in PIP'] = $values['sub_vendor_status_in_pip_id'];
+            $formatted_search_criteria['Sub Vendor Status in PIP'] = $aprv_sta_name;
+          }
         }
       }
+      
       if ($values['purpose']) {
         $form['filter']['purpose'] = array(
           '#markup' => '<div><strong>Purpose:</strong> ' . $values['purpose'] . '</div>',
@@ -1814,12 +1821,12 @@ function checkbook_datafeeds_process_contracts_values($form, &$form_state, $data
           preg_match($pattern, $values['catastrophic_event'], $ematches);
           $criteria['value']['catastrophic_event'] = trim($ematches[1], '[ ]');;
         }
-      }
-      if ($values['contract_includes_sub_vendors_id'] != '' && $values['contract_includes_sub_vendors_id'] != 0) {
-        $criteria['value']['contract_includes_sub_vendors'] = $values['contract_includes_sub_vendors_id'];
-      }
-      if ($values['sub_vendor_status_in_pip_id'] != 'Select Status' && $values['sub_vendor_status_in_pip_id'] != 0) {
-        $criteria['value']['sub_vendor_status_in_pip'] = $values['sub_vendor_status_in_pip_id'];
+        if ($values['contract_includes_sub_vendors_id'] != '' && $values['contract_includes_sub_vendors_id'] != 0) {
+          $criteria['value']['contract_includes_sub_vendors'] = $values['contract_includes_sub_vendors_id'];
+        }
+        if ($values['sub_vendor_status_in_pip_id'] != 'Select Status' && $values['sub_vendor_status_in_pip_id'] != 0) {
+          $criteria['value']['sub_vendor_status_in_pip'] = $values['sub_vendor_status_in_pip_id'];
+        }
       }
 
       break;

--- a/source/webapp/sites/all/modules/custom/checkbook_datafeeds/js/contracts.js
+++ b/source/webapp/sites/all/modules/custom/checkbook_datafeeds/js/contracts.js
@@ -447,6 +447,19 @@
       const $contractStatus = $('select[name="df_contract_status"]', context);
       const $category = $('#edit-category', context);
       let csval = $('select[name="df_contract_status"]', context).val();
+      
+      if(csval === "pending") {
+        $('#edit-year option:selected').removeAttr('selected');
+        $('#edit-year').attr('disabled','disabled');
+        $("#edit-catastrophic_event").attr('disabled', 'disabled');
+        $("#edit-catastrophic_event").val('');
+        $("#edit-sub_vendor_status_in_pip_id").attr('disabled', 'disabled');
+        $("#edit-sub_vendor_status_in_pip_id").val('');
+        $("#edit-contract_includes_sub_vendors_id").attr('disabled', 'disabled');
+        $("#edit-contract_includes_sub_vendors_id").val('');
+        $.fn.subVendorStatusInPipChange(0, 0);
+      }
+
       let catval = $('#edit-category', context).val();
       let year_value = getYearValue($('#edit-year', context).val());
 
@@ -494,11 +507,16 @@
         $.fn.resetSelectedColumns();
         $.fn.hideShow(csval, catval, datasource);
         $.fn.showHidePrimeAndSubIcon();
-        if (csval == 'pending') {
+        if (csval === 'pending') {
           $('#edit-year option:selected').removeAttr('selected');
           $('#edit-year').attr('disabled','disabled');
           $("#edit-catastrophic_event").attr('disabled', 'disabled');
           $("#edit-catastrophic_event").val('');
+          $("#edit-sub_vendor_status_in_pip_id").attr('disabled', 'disabled');
+          $("#edit-sub_vendor_status_in_pip_id").val('');
+          $("#edit-contract_includes_sub_vendors_id").attr('disabled', 'disabled');
+          $("#edit-contract_includes_sub_vendors_id").val('');
+          $.fn.subVendorStatusInPipChange(0, 0);
         }
         else if( catval != 'revenue') {
           $("#edit-catastrophic_event").removeAttr('disabled');

--- a/source/webapp/sites/all/themes/checkbook3/js/advanced-search.js
+++ b/source/webapp/sites/all/themes/checkbook3/js/advanced-search.js
@@ -966,6 +966,9 @@
               div.ele('registration_date_from').val('').attr("disabled", "disabled");
               div.ele('registration_date_to').val('').attr("disabled", "disabled");
               div.ele('catastrophic_events').val('').attr("disabled", "disabled");
+              div.ele('includes_sub_vendors').val('').attr("disabled", "disabled");
+              div.ele('sub_vendor_status').val('').attr("disabled", "disabled");
+              div.ele('year').val('').attr("disabled", "disabled");
             }
             div.ele('year').attr("disabled", "disabled");
             div.ele('year').val("");


### PR DESCRIPTION
Reset and disable the following fields when 'pending' is selected as contract status for data feeds and/or advanced search (wherever the respective fields are not handled):
- Contract includes sub vendors
- Subvendors status in PIP
- Catastrophic event
- Year