### PR TITLE
Feature nycchkbk 10830 : Spending Advanced Search-All years and Selected Year Navigation of links

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_project/customclasses/spending/SpendingUtil.php
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/customclasses/spending/SpendingUtil.php
@@ -186,21 +186,38 @@ class SpendingUtil{
      * @param $row
      * @return string
      */
-    public static function getPayeeNameLinkUrl($node, $row): string
+    public static function getPayeeNameLinkUrl($node, $row, $isAdvancedSearchPage = false): string
     {
+        $year = RequestUtilities::get("year");
         $calyear = RequestUtilities::get("calyear");
         $year_type = isset($calyear) ? "C" : "B";
-        $issue_date = $row["check_eft_issued_date"] ? $row["check_eft_issued_date"] : date("m/d/Y") ;
-        $year_id = isset($calyear) ? $calyear : self::getFiscalYearIDByDate($issue_date);
+        $year_id = isset($calyear) ? $calyear : (isset($year) ? $year : CheckbookDateUtil::getCurrentFiscalYearId());
+
+        if($isAdvancedSearchPage){
+            $issue_date = $row["check_eft_issued_date"] ? $row["check_eft_issued_date"] : date("m/d/Y") ;
+            $year_id = isset($calyear) ? $calyear : self::getFiscalYearIDByDate($issue_date);
+        }
+
         $vendor_id = $row["vendor_id"];
         $agency_id = $row["agency"];
-        $category_id = $row['spending_category_id'];
         $dashboard = RequestUtilities::get("dashboard");
         $link = $row["is_sub_vendor"] == "No" ? self::getPrimeVendorLink($vendor_id, $agency_id, $year_id, $year_type, $dashboard, true) : self::getSubVendorLink($vendor_id, $agency_id, $year_id, $year_type, $dashboard, true);
-        $year_pattern = '/year\/(\d+)/i';
-        $link = preg_replace($year_pattern,"year/". $year_id ,$link);
-        $category_pattern = '/category\/(\d+)/i';
-        $link = preg_replace($category_pattern,"category/". $category_id ,$link);
+
+        if($isAdvancedSearchPage){
+            $category_id = $row['spending_category_id'];
+            $year_pattern = '/year\/(\d+)/i';
+            $category_pattern = '/category\/(\d+)/i';
+            $link = preg_replace($year_pattern,"year/". $year_id ,$link);
+            $link = preg_replace($category_pattern,"category/". $category_id ,$link);
+            
+            if(!strpos($link, 'category')){
+                $link .= '/category/' . $category_id;
+            }
+            if(!strpos($link, 'year')){
+                $link .= '/year/' . $year_id;
+            }
+        }
+
         return $link;
     }
 

--- a/source/webapp/sites/all/modules/custom/checkbook_project/customclasses/spending/SpendingUtil.php
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/customclasses/spending/SpendingUtil.php
@@ -810,6 +810,13 @@ class SpendingUtil{
         $link = preg_replace($year_pattern,"year/". $year_id ,$link);
         $category_pattern = '/category\/(\d+)/i';
         $link = preg_replace($category_pattern,"category/". $category_id ,$link);
+        if(!strpos($link, 'category')){
+            $link .= '/category/' . $category_id;
+        }
+        if(!strpos($link, 'year')){
+            $link .= '/year/' . $year_id;
+        }
+
         return $link;
     }
 

--- a/source/webapp/sites/all/modules/custom/checkbook_project/customclasses/spending/SpendingUtil.php
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/customclasses/spending/SpendingUtil.php
@@ -194,10 +194,13 @@ class SpendingUtil{
         $year_id = isset($calyear) ? $calyear : self::getFiscalYearIDByDate($issue_date);
         $vendor_id = $row["vendor_id"];
         $agency_id = $row["agency"];
+        $category_id = $row['spending_category_id'];
         $dashboard = RequestUtilities::get("dashboard");
         $link = $row["is_sub_vendor"] == "No" ? self::getPrimeVendorLink($vendor_id, $agency_id, $year_id, $year_type, $dashboard, true) : self::getSubVendorLink($vendor_id, $agency_id, $year_id, $year_type, $dashboard, true);
         $year_pattern = '/year\/(\d+)/i';
         $link = preg_replace($year_pattern,"year/". $year_id ,$link);
+        $category_pattern = '/category\/(\d+)/i';
+        $link = preg_replace($category_pattern,"category/". $category_id ,$link);
         return $link;
     }
 

--- a/source/webapp/sites/all/modules/custom/checkbook_project/customclasses/spending/SpendingUtil.php
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/customclasses/spending/SpendingUtil.php
@@ -784,7 +784,16 @@ class SpendingUtil{
             'dashboard'=>$row["is_sub_vendor"] == "No" ? "mp" : "ms",
             'mwbe' => $mwbe == 4 || $mwbe == 5 ? '4~5' : $mwbe
         );
-        return '/' . self::getLandingPageWidgetUrl($custom_params) . '?expandBottomCont=true';
+
+        $issue_date = $row["check_eft_issued_date"] ? $row["check_eft_issued_date"] : date("m/d/Y") ;
+        $year_id = self::getFiscalYearIDByDate($issue_date);
+        $category_id = $row['spending_category_id'];
+        $link = '/' . self::getLandingPageWidgetUrl($custom_params) . '?expandBottomCont=true';
+        $year_pattern = '/year\/(\d+)/i';
+        $link = preg_replace($year_pattern,"year/". $year_id ,$link);
+        $category_pattern = '/category\/(\d+)/i';
+        $link = preg_replace($category_pattern,"category/". $category_id ,$link);
+        return $link;
     }
 
     /**

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/spending/transaction_page_widgets/766.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/spending/transaction_page_widgets/766.json
@@ -188,7 +188,7 @@
             "expression": "_get_tooltip_markup($row['agency_name'], 40)"
         },
         "agency_name_link": {
-            "expression": " RequestUtil::isNewWindow() ? $row['agency_name_formatted']  : ('<a href=/spending_landing' . _checkbook_project_get_year_url_param_string(false,false,false,true) . SpendingUtil::getDataSourceParams()  . '/category/' . $row['spending_category_id'] . '/agency/'. $row['agency_id']. '?expandBottomCont=true>'. $row['agency_name_formatted'] .'</a>') "
+            "expression": " RequestUtil::isNewWindow() ? $row['agency_name_formatted']  : ('<a href=/spending_landing' . '/yeartype/B/year/' . SpendingUtil::getFiscalYearIDByDate($row['check_eft_issued_date'] ? $row['check_eft_issued_date'] : date('m/d/Y')) . SpendingUtil::getDataSourceParams()  . '/category/' . $row['spending_category_id'] . '/agency/'. $row['agency_id']. '?expandBottomCont=true>'. $row['agency_name_formatted'] .'</a>') "
         },
         "payee_name_formatted":{
             "expression": "_get_tooltip_markup($row['vendor_name'], 34)"

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/spending/transaction_page_widgets/766.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/spending/transaction_page_widgets/766.json
@@ -188,7 +188,7 @@
             "expression": "_get_tooltip_markup($row['agency_name'], 40)"
         },
         "agency_name_link": {
-            "expression": " RequestUtil::isNewWindow() ? $row['agency_name_formatted']  : ('<a href=/spending_landing' . _checkbook_project_get_year_url_param_string(false,false,false,true) . SpendingUtil::getDataSourceParams()  . _checkbook_project_get_url_param_string('category') . '/agency/'. $row['agency_id']. '?expandBottomCont=true>'. $row['agency_name_formatted'] .'</a>') "
+            "expression": " RequestUtil::isNewWindow() ? $row['agency_name_formatted']  : ('<a href=/spending_landing' . _checkbook_project_get_year_url_param_string(false,false,false,true) . SpendingUtil::getDataSourceParams()  . '/category/' . $row['spending_category_id'] . '/agency/'. $row['agency_id']. '?expandBottomCont=true>'. $row['agency_name_formatted'] .'</a>') "
         },
         "payee_name_formatted":{
             "expression": "_get_tooltip_markup($row['vendor_name'], 34)"

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/spending/transaction_page_widgets/766.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/spending/transaction_page_widgets/766.json
@@ -197,7 +197,7 @@
             "expression": "$row['vendor_name']"
         },
         "payee_name_link": {
-            "expression": " RequestUtil::isNewWindow() ||  $row['spending_category_id']==2 ?  $row['payee_name_formatted'] : ('<a href=\"' . SpendingUtil::getPayeeNameLinkUrl($node,$row) . '?expandBottomCont=true' . '\">'. $row['payee_name_formatted'] .'</a>') "
+            "expression": " RequestUtil::isNewWindow() ||  $row['spending_category_id']==2 ?  $row['payee_name_formatted'] : ('<a href=\"' . SpendingUtil::getPayeeNameLinkUrl($node,$row,true) . '?expandBottomCont=true' . '\">'. $row['payee_name_formatted'] .'</a>') "
         },
         "issue_date_formatted":{
             "expression": "(_checkbook_check_isEDCPage()? 'N/A' : $row['check_eft_issued_date'])"


### PR DESCRIPTION
For the following navigation links in advanced search results page, they should carry forward the 'spending category' and 'fiscal year' filter based on the 'spending category' and 'issue date' respectively in its inline row and not based on the selection in advanced search form (URL):
- Vendor name link
- Agency link
- M/WBE category link