### PR TITLE
Feature nycchkbk 11005 - Display 'n/a' for spending details transactions similar to results .

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_export/includes/checkbook_export.inc
+++ b/source/webapp/sites/all/modules/custom/checkbook_export/includes/checkbook_export.inc
@@ -497,8 +497,14 @@ function _checkbook_export_generateExportFile($node, $headers, $exportConfigNode
                   if ($pos !== false) {
                     if ($isList) {
                       //Handle alias
-                      $pos -= 3;
-                      $alias_source_column = substr($sql, $pos, strlen($source_column) + 3);
+                      //Adjust the column fields only when alias fields are present
+                      $alias_val = explode('.',$sql);
+                      if (isset($alias_val[1]))
+                      {
+                        $pos -= 3;
+                        $alias_source_column = substr($sql, $pos, strlen($source_column) + 3);
+                      }
+                      else{ $alias_source_column = $source_column; }
                       $replace = array($source_column => $alias_source_column);
                       $override_sql = str_replace(array_keys($replace), array_values($replace), $override_sql);
                       $source_column = $alias_source_column;

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/spending/transaction_page_widgets/mwbe/706.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/spending/transaction_page_widgets/mwbe/706.json
@@ -171,7 +171,7 @@
         }
     },
     "table_columns": [
-        {"labelAlias":"document_id","column":"disbursement_number_derived","sortSourceColumn":"disbursement_number","exportColumn":"disbursement_number_derived"},
+        {"labelAlias":"document_id","column":"disbursement_number_derived","sortSourceColumn":"disbursement_number","exportColumn":"disbursement_number"},
         {"labelAlias":"payee_name","column":"payee_name_link","sortSourceColumn":"vendor_name","exportColumn":"payee_name_export"},
         {"labelAlias":"is_sub_vendor","column":"is_sub_vendor","sortSourceColumn":"vendor_type","exportColumn":"is_sub_vendor"},
         {"label":"","column":"","export":false},
@@ -221,6 +221,16 @@
             "column":"associated_prime_vendor_name",
             "sourceColumn":"prime_vendor_name",
             "sql":"case when is_prime_or_sub = 'P' then 'N/A' else prime_vendor_name end"
+        },
+        {
+        "column":"reference_document_number_link",
+        "sourceColumn":"reference_document_number",
+        "sql":"case when reference_document_number IS NULL then 'N/A' else reference_document_number end"
+        },
+        {
+        "column":"disbursement_number_derived",
+        "sourceColumn":"disbursement_number",
+        "sql":"case when disbursement_number IS NULL then 'N/A' else disbursement_number end"
         }
     ],
     "adjustParameters":"


### PR DESCRIPTION
Refactored the checkbook_export to apply the alias column filed modification only when the query has alias column. Verified transactions exports with and without alias columns for correct export download.