### PR TITLE
Feature nycchkbk 11016 - Remove mocs column from details transactions results /exports. Update breadcrumbs title.

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_custom_breadcrumbs/customclasses/checkbook_custom_breadcrumbs.php
+++ b/source/webapp/sites/all/modules/custom/checkbook_custom_breadcrumbs/customclasses/checkbook_custom_breadcrumbs.php
@@ -127,6 +127,7 @@ class CustomBreadcrumbs
     } else if (isset($bottomURL) && preg_match('/transactions/', $bottomURL)) {
       $smnid = RequestUtil::getRequestKeyValueFromURL("smnid", $bottomURL);
       $dashboard = RequestUtil::getRequestKeyValueFromURL("dashboard", $bottomURL);
+      $mocs = RequestUtil::getRequestKeyValueFromURL("mocs", $bottomURL);
       $title = NodeSummaryUtil::getInitNodeSummaryTitle($smnid);
       if ($smnid == 720 && $dashboard != 'mp') {
         $title = '';
@@ -148,6 +149,9 @@ class CustomBreadcrumbs
       }
       if ($smnid == 725 || $smnid == 783) {
         $title = $title . " with ";
+      }
+      if (isset($mocs)) {
+        $title = "MOCS Registered COVID19 Contracts";
       }
 
       if (preg_match('/^contracts_landing/', current_path()) && preg_match('/status\/A/', current_path())) {

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/contracts/transaction_page_widgets/expense/939.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/contracts/transaction_page_widgets/expense/939.json
@@ -176,7 +176,7 @@
         $cevent = RequestUtilities::getRequestParamValue('cevent');
         $mocs = RequestUtilities::getRequestParamValue('mocs');
         $node->show_difference = ($smnid == 480 || $smnid == 366 || $smnid == 722);
-        $node->show_moc_registered= ($cevent > 0 || isset($mocs));
+        $node->show_moc_registered= ($cevent > 0 );
         $node->show_spend_to_date = (!isset($mocs));
         $node->dashboard = RequestUtilities::getRequestParamValue('dashboard');
         $node->dashboard = RequestUtilities::getRequestParamValue('dashboard');

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/contracts/transaction_page_widgets/expense/962.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/contracts/transaction_page_widgets/expense/962.json
@@ -47,7 +47,7 @@
         $cevent = RequestUtilities::getRequestParamValue('cevent');
         $mocs = RequestUtilities::getRequestParamValue('mocs');
         $node->show_difference = ($smnid == 480 || $smnid == 366 || $smnid == 722);
-        $node->show_moc_registered = ($cevent > 0 || isset($mocs));
+        $node->show_moc_registered = ($cevent > 0 );
         $node->show_spend_to_date = (!isset($mocs));
     "
 }


### PR DESCRIPTION
Verified mocs column displayed for advanced search when covid filter is applied.