### PR TITLE
Feature nycchkbk 11155(update) - Title not displaying correctly when category filter is in the end of url parameter.

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_project/customclasses/spending/SpendingUtil.php
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/customclasses/spending/SpendingUtil.php
@@ -168,20 +168,31 @@ class SpendingUtil{
      *
      * @param $node
      * @param $row
+     * @param null $category_id
      * @return string
      */
-    public static function getPayeeNameLinkUrl($node, $row): string
+    public static function getPayeeNameLinkUrl($node, $row,$category_id = null): string
     {
         $year_id = isset($row['check_eft_issued_nyc_year_id']) ? $row['check_eft_issued_nyc_year_id'] : CheckbookDateUtil::getCurrentFiscalYearId();
         $vendor_id = $row["vendor_id"];
         $agency_id = $row["agency"];
         $dashboard = RequestUtilities::get("dashboard");
         $year_type = 'B';
-        $category = $row["spending_category_id"];
+        $nid = $node->nid;
 
-        return $row["is_sub_vendor"] == "No"
-            ? self::getPrimeVendorLink($vendor_id, $agency_id, $year_id, $year_type, $dashboard, true)
-            : self::getSubVendorLink($vendor_id, $agency_id, $year_id, $year_type, $dashboard, true);
+        $url = $row["is_sub_vendor"] == "No"
+          ? self::getPrimeVendorLink($vendor_id, $agency_id, $year_id, $year_type, $dashboard, true)
+          : self::getSubVendorLink($vendor_id, $agency_id, $year_id, $year_type, $dashboard, true);
+
+        // Title does not display correctly for payee name link from advanced search
+        // when the category filter is added in the end of the url parameters
+        // move the category parameter to the beginning of the url
+
+        if ($nid == 766){
+          $replace = 'spending_landing/category/'.$category_id;
+          $url = preg_replace('/spending_landing/', $replace, $url);
+        }
+        return $url;
 
     }
 

--- a/source/webapp/sites/all/modules/custom/checkbook_project/customclasses/spending/SpendingUtil.php
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/customclasses/spending/SpendingUtil.php
@@ -170,18 +170,24 @@ class SpendingUtil{
      * @param $row
      * @return string
      */
-    public static function getPayeeNameLinkUrl($node, $row): string
+    public static function getPayeeNameLinkUrl($node, $row,$category_id = null): string
     {
         $year_id = isset($row['check_eft_issued_nyc_year_id']) ? $row['check_eft_issued_nyc_year_id'] : CheckbookDateUtil::getCurrentFiscalYearId();
         $vendor_id = $row["vendor_id"];
         $agency_id = $row["agency"];
         $dashboard = RequestUtilities::get("dashboard");
         $year_type = 'B';
-        $category = $row["spending_category_id"];
+        $nid = $node->nid;
 
-        return $row["is_sub_vendor"] == "No"
-            ? self::getPrimeVendorLink($vendor_id, $agency_id, $year_id, $year_type, $dashboard, true)
-            : self::getSubVendorLink($vendor_id, $agency_id, $year_id, $year_type, $dashboard, true);
+        $url = $row["is_sub_vendor"] == "No"
+          ? self::getPrimeVendorLink($vendor_id, $agency_id, $year_id, $year_type, $dashboard, true)
+          : self::getSubVendorLink($vendor_id, $agency_id, $year_id, $year_type, $dashboard, true);
+
+        if ($nid = 766){
+          $replace = 'spending_landing/category/'.$category_id;
+          $url = preg_replace('/spending_landing/', $replace, $url);
+        }
+        return $url;
 
     }
 

--- a/source/webapp/sites/all/modules/custom/checkbook_project/customclasses/spending/SpendingUtil.php
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/customclasses/spending/SpendingUtil.php
@@ -170,24 +170,18 @@ class SpendingUtil{
      * @param $row
      * @return string
      */
-    public static function getPayeeNameLinkUrl($node, $row,$category_id = null): string
+    public static function getPayeeNameLinkUrl($node, $row): string
     {
         $year_id = isset($row['check_eft_issued_nyc_year_id']) ? $row['check_eft_issued_nyc_year_id'] : CheckbookDateUtil::getCurrentFiscalYearId();
         $vendor_id = $row["vendor_id"];
         $agency_id = $row["agency"];
         $dashboard = RequestUtilities::get("dashboard");
         $year_type = 'B';
-        $nid = $node->nid;
+        $category = $row["spending_category_id"];
 
-        $url = $row["is_sub_vendor"] == "No"
-          ? self::getPrimeVendorLink($vendor_id, $agency_id, $year_id, $year_type, $dashboard, true)
-          : self::getSubVendorLink($vendor_id, $agency_id, $year_id, $year_type, $dashboard, true);
-
-        if ($nid = 766){
-          $replace = 'spending_landing/category/'.$category_id;
-          $url = preg_replace('/spending_landing/', $replace, $url);
-        }
-        return $url;
+        return $row["is_sub_vendor"] == "No"
+            ? self::getPrimeVendorLink($vendor_id, $agency_id, $year_id, $year_type, $dashboard, true)
+            : self::getSubVendorLink($vendor_id, $agency_id, $year_id, $year_type, $dashboard, true);
 
     }
 

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/spending/transaction_page_widgets/766.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/spending/transaction_page_widgets/766.json
@@ -204,7 +204,7 @@
             "expression": "$row['vendor_name']"
         },
         "payee_name_link": {
-            "expression": " RequestUtil::isNewWindow() ||  $row['spending_category_id']==2 ?  $row['payee_name_formatted'] : ('<a href=\"' . SpendingUtil::getPayeeNameLinkUrl($node,$row,$row['spending_category_id'])  .'?expandBottomCont=true' . '\">'. $row['payee_name_formatted'] .'</a>') "
+            "expression": " RequestUtil::isNewWindow() ||  $row['spending_category_id']==2 ?  $row['payee_name_formatted'] : ('<a href=\"' . SpendingUtil::getPayeeNameLinkUrl($node,$row) .'/category/'.$row['spending_category_id'] .'?expandBottomCont=true' . '\">'. $row['payee_name_formatted'] .'</a>') "
         },
         "issue_date_formatted":{
             "expression": "(_checkbook_check_isEDCPage()? 'N/A' : $row['check_eft_issued_date'])"

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/spending/transaction_page_widgets/766.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/spending/transaction_page_widgets/766.json
@@ -204,7 +204,7 @@
             "expression": "$row['vendor_name']"
         },
         "payee_name_link": {
-            "expression": " RequestUtil::isNewWindow() ||  $row['spending_category_id']==2 ?  $row['payee_name_formatted'] : ('<a href=\"' . SpendingUtil::getPayeeNameLinkUrl($node,$row) .'/category/'.$row['spending_category_id'] .'?expandBottomCont=true' . '\">'. $row['payee_name_formatted'] .'</a>') "
+            "expression": " RequestUtil::isNewWindow() ||  $row['spending_category_id']==2 ?  $row['payee_name_formatted'] : ('<a href=\"' . SpendingUtil::getPayeeNameLinkUrl($node,$row,$row['spending_category_id']) .'?expandBottomCont=true' . '\">'. $row['payee_name_formatted'] .'</a>') "
         },
         "issue_date_formatted":{
             "expression": "(_checkbook_check_isEDCPage()? 'N/A' : $row['check_eft_issued_date'])"

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/spending/transaction_page_widgets/766.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/spending/transaction_page_widgets/766.json
@@ -204,7 +204,7 @@
             "expression": "$row['vendor_name']"
         },
         "payee_name_link": {
-            "expression": " RequestUtil::isNewWindow() ||  $row['spending_category_id']==2 ?  $row['payee_name_formatted'] : ('<a href=\"' . SpendingUtil::getPayeeNameLinkUrl($node,$row) .'/category/'.$row['spending_category_id'] .'?expandBottomCont=true' . '\">'. $row['payee_name_formatted'] .'</a>') "
+            "expression": " RequestUtil::isNewWindow() ||  $row['spending_category_id']==2 ?  $row['payee_name_formatted'] : ('<a href=\"' . SpendingUtil::getPayeeNameLinkUrl($node,$row,$row['spending_category_id'])  .'?expandBottomCont=true' . '\">'. $row['payee_name_formatted'] .'</a>') "
         },
         "issue_date_formatted":{
             "expression": "(_checkbook_check_isEDCPage()? 'N/A' : $row['check_eft_issued_date'])"


### PR DESCRIPTION
The title does not display correctly from payee name link in advanced search when the category filter is at the end of the url parameters because title display uses _getLastRequestParamValue().