### PR TITLE
Feature nycchkbk 11004(update) - Budget code facet to not display empty values.

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/narrow_down_filters/spending/1066.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/narrow_down_filters/spending/1066.json
@@ -29,9 +29,7 @@ $parameters = _checkbook_project_adjust_spending_parameter_filters($node, $param
 }
 if(function_exists('_checkbook_project_applyParameterFilters')){
 $adjustedParameters = _checkbook_project_applyParameterFilters($node,$parameters);
-
 $adjustedParameters['budget_name_code.budget_name_code'][] = data_controller_get_operator_factory_instance()->initiateHandler(NotEmptyOperatorHandler::$OPERATOR__NAME);
-$adjustedParameters['budget_name_code.budget_name_code'][] = data_controller_get_operator_factory_instance()->initiateHandler(NotEqualOperatorHandler::$OPERATOR__NAME,'');
 return $adjustedParameters;
 }
 return $parameters;

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/narrow_down_filters/spending/1066.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/narrow_down_filters/spending/1066.json
@@ -29,7 +29,9 @@ $parameters = _checkbook_project_adjust_spending_parameter_filters($node, $param
 }
 if(function_exists('_checkbook_project_applyParameterFilters')){
 $adjustedParameters = _checkbook_project_applyParameterFilters($node,$parameters);
+
 $adjustedParameters['budget_name_code.budget_name_code'][] = data_controller_get_operator_factory_instance()->initiateHandler(NotEmptyOperatorHandler::$OPERATOR__NAME);
+$adjustedParameters['budget_name_code.budget_name_code'][] = data_controller_get_operator_factory_instance()->initiateHandler(NotEqualOperatorHandler::$OPERATOR__NAME,'');
 return $adjustedParameters;
 }
 return $parameters;

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/narrow_down_filters/spending/1066.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/narrow_down_filters/spending/1066.json
@@ -30,6 +30,7 @@ $parameters = _checkbook_project_adjust_spending_parameter_filters($node, $param
 if(function_exists('_checkbook_project_applyParameterFilters')){
 $adjustedParameters = _checkbook_project_applyParameterFilters($node,$parameters);
 $adjustedParameters['budget_name_code.budget_name_code'][] = data_controller_get_operator_factory_instance()->initiateHandler(NotEmptyOperatorHandler::$OPERATOR__NAME);
+$adjustedParameters['budget_name_code.budget_name_code'][] = data_controller_get_operator_factory_instance()->initiateHandler(NotEqualOperatorHandler::$OPERATOR__NAME,'');
 return $adjustedParameters;
 }
 return $parameters;

--- a/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/narrow_down_filters/spending/mwbe/1065.json
+++ b/source/webapp/sites/all/modules/custom/checkbook_project/widget_config/narrow_down_filters/spending/mwbe/1065.json
@@ -27,6 +27,7 @@ $parameters = _checkbook_project_adjust_spending_parameter_filters($node, $param
 if(function_exists('_checkbook_project_applyParameterFilters')){
 $adjustedParameters = _checkbook_project_applyParameterFilters($node,$parameters);
 $adjustedParameters['budget_name_code.budget_name_code'][] = data_controller_get_operator_factory_instance()->initiateHandler(NotEmptyOperatorHandler::$OPERATOR__NAME);
+$adjustedParameters['budget_name_code.budget_name_code'][] = data_controller_get_operator_factory_instance()->initiateHandler(NotEqualOperatorHandler::$OPERATOR__NAME,'');
 return $adjustedParameters;
 }
 return $parameters;

--- a/source/webapp/sites/all/modules/dashboard_platform/data_controller_datasource/sql/core/query/datasource/operator/handler/SQL_NotEqualOperatorHandler.php
+++ b/source/webapp/sites/all/modules/dashboard_platform/data_controller_datasource/sql/core/query/datasource/operator/handler/SQL_NotEqualOperatorHandler.php
@@ -1,19 +1,19 @@
 <?php
 /**
 * This file is part of the Checkbook NYC financial transparency software.
-*
+* 
 * Copyright (C) 2012, 2013 New York City
-*
+* 
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU Affero General Public License as
 * published by the Free Software Foundation, either version 3 of the
 * License, or (at your option) any later version.
-*
+* 
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU Affero General Public License for more details.
-*
+* 
 * You should have received a copy of the GNU Affero General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -26,6 +26,10 @@ class SQL_NotEqualOperatorHandler extends SQL_AbstractOperatorHandler {
     protected function prepareExpression(DataControllerCallContext $callcontext, AbstractRequest $request, $datasetName, $columnName, $columnDataType) {
         $value = $this->getParameterValue('value');
 
+        if (!isset($value)) {
+            return ' IS NOT NULL';
+        }
+
         if (is_array($value)) {
             $values = NULL;
             foreach ($value as $v) {
@@ -35,8 +39,7 @@ class SQL_NotEqualOperatorHandler extends SQL_AbstractOperatorHandler {
             $formattedValue = ' NOT IN (' . implode(', ', $values) . ')';
         }
         else {
-            // if $value is '' make sure to set it to '' to check for not empty values
-            $formattedValue = $value != NULL ? ' != ' . $this->datasourceHandler->formatValue($columnDataType, $value) : ' != \'\'' ;
+            $formattedValue = ' != ' . $this->datasourceHandler->formatValue($columnDataType, $value);
         }
 
         return $formattedValue;

--- a/source/webapp/sites/all/modules/dashboard_platform/data_controller_datasource/sql/core/query/datasource/operator/handler/SQL_NotEqualOperatorHandler.php
+++ b/source/webapp/sites/all/modules/dashboard_platform/data_controller_datasource/sql/core/query/datasource/operator/handler/SQL_NotEqualOperatorHandler.php
@@ -35,8 +35,8 @@ class SQL_NotEqualOperatorHandler extends SQL_AbstractOperatorHandler {
             $formattedValue = ' NOT IN (' . implode(', ', $values) . ')';
         }
         else {
-            // if $value is '' make sure to set it to '' to check for not empty values
-            $formattedValue = $value != NULL ? ' != ' . $this->datasourceHandler->formatValue($columnDataType, $value) : ' != \'\'' ;
+            // if $value is '' make sure to set it to '' to check for not empty values applicable only to strings
+            $formattedValue = ($value == NULL && $columnDataType != 'integer') ? ' != \'\'' : ' != ' . $this->datasourceHandler->formatValue($columnDataType, $value);
         }
 
         return $formattedValue;

--- a/source/webapp/sites/all/modules/dashboard_platform/data_controller_datasource/sql/core/query/datasource/operator/handler/SQL_NotEqualOperatorHandler.php
+++ b/source/webapp/sites/all/modules/dashboard_platform/data_controller_datasource/sql/core/query/datasource/operator/handler/SQL_NotEqualOperatorHandler.php
@@ -1,19 +1,19 @@
 <?php
 /**
 * This file is part of the Checkbook NYC financial transparency software.
-* 
+*
 * Copyright (C) 2012, 2013 New York City
-* 
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU Affero General Public License as
 * published by the Free Software Foundation, either version 3 of the
 * License, or (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU Affero General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU Affero General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -26,10 +26,6 @@ class SQL_NotEqualOperatorHandler extends SQL_AbstractOperatorHandler {
     protected function prepareExpression(DataControllerCallContext $callcontext, AbstractRequest $request, $datasetName, $columnName, $columnDataType) {
         $value = $this->getParameterValue('value');
 
-        if (!isset($value)) {
-            return ' IS NOT NULL';
-        }
-
         if (is_array($value)) {
             $values = NULL;
             foreach ($value as $v) {
@@ -39,7 +35,8 @@ class SQL_NotEqualOperatorHandler extends SQL_AbstractOperatorHandler {
             $formattedValue = ' NOT IN (' . implode(', ', $values) . ')';
         }
         else {
-            $formattedValue = ' != ' . $this->datasourceHandler->formatValue($columnDataType, $value);
+            // if $value is '' make sure to set it to '' to check for not empty values
+            $formattedValue = $value != NULL ? ' != ' . $this->datasourceHandler->formatValue($columnDataType, $value) : ' != \'\'' ;
         }
 
         return $formattedValue;


### PR DESCRIPTION
The query takes care of not null values in the facet. This works fine when the datatype is integer. When the data type is string not null checks only for null values. To check empty the query has to be update accordingly. The fix below handles the issue. 
To check for null use NotEmptyOperatorHandler. To check for empty use NotEqualOperatorHandler ( especially when the datatype is string).
