### PR TITLE
NYCCHKBK-11310: Increased max record limit to 20k for API response

### DIFF
--- a/source/webapp/sites/all/modules/custom/checkbook_api/criteria/XMLSearchCriteria.php
+++ b/source/webapp/sites/all/modules/custom/checkbook_api/criteria/XMLSearchCriteria.php
@@ -1,19 +1,19 @@
 <?php
 /**
 * This file is part of the Checkbook NYC financial transparency software.
-* 
+*
 * Copyright (C) 2012, 2013 New York City
-* 
+*
 * This program is free software: you can redistribute it and/or modify
 * it under the terms of the GNU Affero General Public License as
 * published by the Free Software Foundation, either version 3 of the
 * License, or (at your option) any later version.
-* 
+*
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU Affero General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU Affero General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -201,7 +201,7 @@ class XMLSearchCriteria extends AbstractAPISearchCriteria {
    * @return int|mixed
    */
   function getMaxAllowedTransactionResults() {
-    return 1000;
+    return 20000;
   }
     /**
      * @return mixed


### PR DESCRIPTION
Verified - data load and size for all domains/data-sources (20k is the maximum limit for Postman and REST client)